### PR TITLE
M1.5: privileged helper (SMAppService) + XPC + watchdog + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tools
+        run: brew install xcodegen xcbeautify
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      - name: Build & test
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -scheme Lidless-CI \
+            -destination 'platform=macOS' \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcbeautify

--- a/Resources/com.nghialuong.lidless.helper.plist
+++ b/Resources/com.nghialuong.lidless.helper.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nghialuong.lidless.helper</string>
+    <key>BundleProgram</key>
+    <string>Contents/MacOS/LidlessHelper</string>
+    <key>MachServices</key>
+    <dict>
+        <key>com.nghialuong.lidless.helper</key>
+        <true/>
+    </dict>
+    <key>AssociatedBundleIdentifiers</key>
+    <array>
+        <string>com.nghialuong.lidless</string>
+    </array>
+</dict>
+</plist>

--- a/Sources/Helper/HelperService.swift
+++ b/Sources/Helper/HelperService.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+final class HelperListenerDelegate: NSObject, NSXPCListenerDelegate {
+    private let service = HelperService()
+
+    func listener(_ listener: NSXPCListener,
+                  shouldAcceptNewConnection newConnection: NSXPCConnection) -> Bool {
+        newConnection.exportedInterface = NSXPCInterface(with: LidlessHelperProtocol.self)
+        newConnection.exportedObject = service
+        newConnection.resume()
+        return true
+    }
+}
+
+/// The actual privileged work. Runs as root, so it can call `pmset` directly
+/// with no admin prompt. Guards against a stuck-awake state with a watchdog.
+final class HelperService: NSObject, LidlessHelperProtocol {
+    private let queue = DispatchQueue(label: "com.nghialuong.lidless.helper.state")
+    private var lastHeartbeat = Date()
+    private var keepAwake = false
+    private let watchdogTimeout: TimeInterval = 90
+    private var watchdogTimer: DispatchSourceTimer?
+
+    override init() {
+        super.init()
+        startWatchdog()
+    }
+
+    // MARK: LidlessHelperProtocol
+
+    func setKeepAwake(_ enabled: Bool, withReply reply: @escaping (Bool, String?) -> Void) {
+        queue.async {
+            let result = self.runPmset(disableSleep: enabled)
+            if result.ok {
+                self.keepAwake = enabled
+                self.lastHeartbeat = Date()
+            }
+            reply(result.ok, result.error)
+        }
+    }
+
+    func getState(withReply reply: @escaping (Bool) -> Void) {
+        let out = Self.capture("/usr/bin/pmset", ["-g"]) ?? ""
+        reply(PowerParsers.isSleepDisabled(pmsetG: out))
+    }
+
+    func heartbeat(withReply reply: @escaping (Bool) -> Void) {
+        queue.async {
+            self.lastHeartbeat = Date()
+            reply(true)
+        }
+    }
+
+    func version(withReply reply: @escaping (String) -> Void) {
+        reply("0.1.0")
+    }
+
+    // MARK: Watchdog
+
+    private func startWatchdog() {
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + 30, repeating: 30)
+        timer.setEventHandler { [weak self] in
+            guard let self = self, self.keepAwake else { return }
+            if Watchdog.shouldAutoRestore(lastHeartbeat: self.lastHeartbeat,
+                                          now: Date(),
+                                          timeout: self.watchdogTimeout) {
+                _ = self.runPmset(disableSleep: false)
+                self.keepAwake = false
+            }
+        }
+        timer.resume()
+        watchdogTimer = timer
+    }
+
+    // MARK: Shell
+
+    @discardableResult
+    private func runPmset(disableSleep: Bool) -> (ok: Bool, error: String?) {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/pmset")
+        proc.arguments = ["-a", "disablesleep", disableSleep ? "1" : "0"]
+        let errPipe = Pipe()
+        proc.standardError = errPipe
+        do {
+            try proc.run()
+        } catch {
+            return (false, error.localizedDescription)
+        }
+        proc.waitUntilExit()
+        if proc.terminationStatus != 0 {
+            let data = errPipe.fileHandleForReading.readDataToEndOfFile()
+            let msg = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return (false, msg.isEmpty ? "pmset exited \(proc.terminationStatus)" : msg)
+        }
+        return (true, nil)
+    }
+
+    private static func capture(_ path: String, _ args: [String]) -> String? {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: path)
+        proc.arguments = args
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = Pipe()
+        do {
+            try proc.run()
+        } catch {
+            return nil
+        }
+        proc.waitUntilExit()
+        return String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+    }
+}

--- a/Sources/Helper/main.swift
+++ b/Sources/Helper/main.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+// Entry point for the privileged helper (a LaunchDaemon running as root).
+// It listens on a Mach service and serves LidlessHelperProtocol over XPC.
+let delegate = HelperListenerDelegate()
+let listener = NSXPCListener(machServiceName: lidlessHelperMachLabel)
+listener.delegate = delegate
+listener.resume()
+RunLoop.current.run()

--- a/Sources/Lidless/AppState.swift
+++ b/Sources/Lidless/AppState.swift
@@ -3,38 +3,116 @@ import Foundation
 
 @MainActor
 final class AppState: ObservableObject {
-    @Published var isEnabled: Bool = false
-    @Published var batteryDescription: String = ""
+    @Published var isEnabled = false
+    @Published var helperInstalled = false
+    @Published var helperNeedsApproval = false
+    @Published var batteryDescription = ""
     @Published var lastError: String?
 
-    private let power = PowerManager()
+    /// True when using the privileged helper; false when on the M1 admin-prompt fallback.
+    @Published var usingHelper = false
+
+    private let helper = HelperManager()
+    private let fallback = PowerManager()
     private let battery = BatteryMonitor()
-    private var timer: Timer?
+    private var batteryTimer: Timer?
+    private var heartbeatTimer: Timer?
+    private let lowBatteryThreshold = 20
 
     init() {
-        isEnabled = power.isSleepDisabled()
+        refreshHelperStatus()
+        refreshState()
         refreshBattery()
-        timer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
-            Task { @MainActor in self?.refreshBattery() }
+        batteryTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.tick() }
         }
     }
 
-    /// Flip the keep-awake state. Prompts for admin (M1 via pmset).
-    func toggle() {
-        let target = !isEnabled
+    // MARK: Helper lifecycle
+
+    func refreshHelperStatus() {
+        helperInstalled = helper.isEnabled
+        helperNeedsApproval = helper.requiresApproval
+        usingHelper = helperInstalled
+    }
+
+    func installHelper() {
         do {
-            try power.setSleepDisabled(target)
-            isEnabled = target
-            lastError = nil
+            try helper.register()
+            refreshHelperStatus()
+            if helper.requiresApproval {
+                lastError = "Approve Lidless in System Settings ▸ Login Items."
+                helper.openLoginItemsSettings()
+            } else {
+                lastError = nil
+            }
         } catch {
             lastError = error.localizedDescription
-            // Re-sync with the real flag in case the change partially applied.
-            isEnabled = power.isSleepDisabled()
+        }
+    }
+
+    // MARK: State
+
+    func refreshState() {
+        if helperInstalled {
+            helper.getState { [weak self] value in self?.isEnabled = value }
+        } else {
+            isEnabled = fallback.isSleepDisabled()
+        }
+    }
+
+    func toggle() { setEnabled(!isEnabled) }
+
+    func setEnabled(_ target: Bool) {
+        if helperInstalled {
+            helper.setKeepAwake(target) { [weak self] ok, err in
+                guard let self else { return }
+                if ok {
+                    self.isEnabled = target
+                    self.lastError = nil
+                    self.manageHeartbeat()
+                } else {
+                    self.lastError = err
+                    self.refreshState()
+                }
+            }
+        } else {
+            do {
+                try fallback.setSleepDisabled(target)
+                isEnabled = target
+                lastError = nil
+            } catch {
+                lastError = error.localizedDescription
+                isEnabled = fallback.isSleepDisabled()
+            }
+        }
+    }
+
+    // MARK: Heartbeat (keeps the helper watchdog satisfied)
+
+    private func manageHeartbeat() {
+        heartbeatTimer?.invalidate()
+        heartbeatTimer = nil
+        guard isEnabled, helperInstalled else { return }
+        helper.heartbeat()
+        heartbeatTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
+            self?.helper.heartbeat()
+        }
+    }
+
+    // MARK: Battery + safety guard
+
+    func tick() {
+        refreshBattery()
+        let info = battery.read()
+        if isEnabled, SafetyPolicy.shouldDisableForBattery(info, threshold: lowBatteryThreshold) {
+            setEnabled(false)
+            lastError = "Auto-disabled: battery \(info.percent)% on battery power."
         }
     }
 
     func refreshBattery() {
-        let b = battery.read()
-        batteryDescription = "\(b.source) · \(b.percent)%"
+        let info = battery.read()
+        batteryDescription = "\(info.source) · \(info.percent)%"
     }
 }

--- a/Sources/Lidless/BatteryMonitor.swift
+++ b/Sources/Lidless/BatteryMonitor.swift
@@ -1,24 +1,10 @@
 import Foundation
 
-struct BatteryInfo {
-    let percent: Int
-    let source: String   // "AC" or "Battery"
-}
-
 /// Reads battery level + power source by parsing `pmset -g batt`.
-/// TODO (M2): switch to IOPowerSources for live notifications + the low-battery
-/// safety guard (auto-clear SleepDisabled below a threshold).
+/// TODO (M2): switch to IOPowerSources for live notifications.
 struct BatteryMonitor {
     func read() -> BatteryInfo {
         let out = Shell.capture("/usr/bin/pmset", ["-g", "batt"]) ?? ""
-
-        var percent = 0
-        if let range = out.range(of: #"\d+%"#, options: .regularExpression) {
-            let token = out[range].dropLast() // strip "%"
-            percent = Int(token) ?? 0
-        }
-
-        let source = out.contains("AC Power") ? "AC" : "Battery"
-        return BatteryInfo(percent: percent, source: source)
+        return BatteryParsers.parse(pmsetBatt: out)
     }
 }

--- a/Sources/Lidless/HelperManager.swift
+++ b/Sources/Lidless/HelperManager.swift
@@ -1,0 +1,73 @@
+import Foundation
+import ServiceManagement
+
+/// Manages the privileged helper: registration via SMAppService and XPC calls.
+/// All completion handlers are delivered on the main queue.
+final class HelperManager {
+    static let plistName = "com.nghialuong.lidless.helper.plist"
+
+    private var connection: NSXPCConnection?
+
+    private var service: SMAppService {
+        SMAppService.daemon(plistName: Self.plistName)
+    }
+
+    // MARK: Registration
+
+    var isEnabled: Bool { service.status == .enabled }
+    var requiresApproval: Bool { service.status == .requiresApproval }
+
+    /// Register the daemon. Throws if registration fails outright. After this,
+    /// `status` may be `.requiresApproval` until the user approves in Settings.
+    func register() throws { try service.register() }
+
+    func unregister() throws { try service.unregister() }
+
+    func openLoginItemsSettings() {
+        SMAppService.openSystemSettingsLoginItems()
+    }
+
+    // MARK: XPC
+
+    private func connect() -> NSXPCConnection {
+        if let existing = connection { return existing }
+        let conn = NSXPCConnection(machServiceName: lidlessHelperMachLabel, options: .privileged)
+        conn.remoteObjectInterface = NSXPCInterface(with: LidlessHelperProtocol.self)
+        conn.invalidationHandler = { [weak self] in self?.connection = nil }
+        conn.interruptionHandler = { }
+        conn.resume()
+        connection = conn
+        return conn
+    }
+
+    private func remote(_ onError: @escaping (String) -> Void) -> LidlessHelperProtocol? {
+        let proxy = connect().remoteObjectProxyWithErrorHandler { error in
+            DispatchQueue.main.async { onError(error.localizedDescription) }
+        }
+        return proxy as? LidlessHelperProtocol
+    }
+
+    func setKeepAwake(_ enabled: Bool, completion: @escaping (Bool, String?) -> Void) {
+        guard let r = remote({ completion(false, $0) }) else {
+            completion(false, "No helper connection")
+            return
+        }
+        r.setKeepAwake(enabled) { ok, err in
+            DispatchQueue.main.async { completion(ok, err) }
+        }
+    }
+
+    func getState(completion: @escaping (Bool) -> Void) {
+        guard let r = remote({ _ in completion(false) }) else {
+            completion(false)
+            return
+        }
+        r.getState { value in
+            DispatchQueue.main.async { completion(value) }
+        }
+    }
+
+    func heartbeat() {
+        remote({ _ in })?.heartbeat { _ in }
+    }
+}

--- a/Sources/Lidless/MenuContent.swift
+++ b/Sources/Lidless/MenuContent.swift
@@ -23,7 +23,25 @@ struct MenuContent: View {
 
             Divider()
 
-            HStack {
+            // Helper / mode row
+            HStack(spacing: 6) {
+                Image(systemName: state.usingHelper ? "checkmark.shield.fill" : "exclamationmark.shield")
+                    .foregroundStyle(state.usingHelper ? .green : .orange)
+                Text(state.usingHelper
+                     ? "Background helper active"
+                     : "Using admin prompt (no helper)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if !state.helperInstalled {
+                Button(state.helperNeedsApproval ? "Open Login Items to approve" : "Install background helper") {
+                    state.installHelper()
+                }
+                .font(.caption)
+            }
+
+            HStack(spacing: 6) {
                 Image(systemName: "battery.100")
                     .foregroundStyle(.secondary)
                 Text(state.batteryDescription)
@@ -46,6 +64,6 @@ struct MenuContent: View {
             }
         }
         .padding(12)
-        .frame(width: 260)
+        .frame(width: 270)
     }
 }

--- a/Sources/Lidless/PowerManager.swift
+++ b/Sources/Lidless/PowerManager.swift
@@ -13,13 +13,7 @@ struct PowerManager {
     /// Read the current `SleepDisabled` flag from `pmset -g`.
     func isSleepDisabled() -> Bool {
         guard let out = Shell.capture("/usr/bin/pmset", ["-g"]) else { return false }
-        for rawLine in out.split(separator: "\n") {
-            let line = rawLine.lowercased()
-            if line.contains("sleepdisabled") {
-                return line.contains(" 1")
-            }
-        }
-        return false
+        return PowerParsers.isSleepDisabled(pmsetG: out)
     }
 
     /// Set or clear the flag. Throws with the underlying error message on failure

--- a/Sources/Shared/HelperProtocol.swift
+++ b/Sources/Shared/HelperProtocol.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Mach service name shared by the app (client) and the privileged helper (server).
+public let lidlessHelperMachLabel = "com.nghialuong.lidless.helper"
+
+/// XPC interface implemented by the root helper and called by the app.
+///
+/// The helper runs as root (installed via `SMAppService`), so it can flip the
+/// `SleepDisabled` flag without an admin prompt. A heartbeat watchdog inside the
+/// helper auto-restores normal sleep if the app stops checking in — so the Mac
+/// can never get stuck awake if the app crashes or is force-quit.
+@objc public protocol LidlessHelperProtocol {
+    /// Enable/disable lid-close sleep prevention. reply: (success, errorMessage?).
+    func setKeepAwake(_ enabled: Bool, withReply reply: @escaping (Bool, String?) -> Void)
+
+    /// Read the current SleepDisabled flag. reply: (enabled).
+    func getState(withReply reply: @escaping (Bool) -> Void)
+
+    /// Heartbeat from the app; resets the watchdog timer.
+    func heartbeat(withReply reply: @escaping (Bool) -> Void)
+
+    /// Helper version string, for a connection sanity check.
+    func version(withReply reply: @escaping (String) -> Void)
+}

--- a/Sources/Shared/PowerParsers.swift
+++ b/Sources/Shared/PowerParsers.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Pure parsing helpers for `pmset` output. Kept free of side effects so they
+/// can be unit-tested without touching real power management.
+public enum PowerParsers {
+
+    /// Parse `pmset -g` output and return whether the `SleepDisabled` flag is set.
+    /// The relevant line looks like: ` SleepDisabled        1`
+    public static func isSleepDisabled(pmsetG output: String) -> Bool {
+        for raw in output.split(separator: "\n") {
+            let line = String(raw).lowercased()
+            guard line.contains("sleepdisabled") else { continue }
+            let remainder = line
+                .replacingOccurrences(of: "sleepdisabled", with: "")
+                .trimmingCharacters(in: .whitespaces)
+            return remainder == "1"
+        }
+        return false
+    }
+}
+
+public struct BatteryInfo: Equatable {
+    public let percent: Int
+    public let onAC: Bool
+
+    public init(percent: Int, onAC: Bool) {
+        self.percent = percent
+        self.onAC = onAC
+    }
+
+    public var source: String { onAC ? "AC" : "Battery" }
+}
+
+public enum BatteryParsers {
+    /// Parse `pmset -g batt` output into a BatteryInfo.
+    public static func parse(pmsetBatt output: String) -> BatteryInfo {
+        var percent = 0
+        if let range = output.range(of: #"\d+%"#, options: .regularExpression) {
+            percent = Int(output[range].dropLast()) ?? 0
+        }
+        let onAC = output.contains("AC Power")
+        return BatteryInfo(percent: percent, onAC: onAC)
+    }
+}

--- a/Sources/Shared/Safety.swift
+++ b/Sources/Shared/Safety.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Watchdog decision logic (pure, unit-testable).
+public enum Watchdog {
+    /// True when the app has gone quiet longer than `timeout`, so the helper
+    /// should auto-restore normal sleep.
+    public static func shouldAutoRestore(lastHeartbeat: Date, now: Date, timeout: TimeInterval) -> Bool {
+        now.timeIntervalSince(lastHeartbeat) > timeout
+    }
+}
+
+/// Battery safety policy (pure, unit-testable).
+public enum SafetyPolicy {
+    /// True when keep-awake should be auto-disabled to protect the battery:
+    /// running on battery (not AC) at or below the threshold percent.
+    public static func shouldDisableForBattery(_ info: BatteryInfo, threshold: Int) -> Bool {
+        !info.onAC && info.percent <= threshold
+    }
+}

--- a/Tests/LidlessTests/SharedLogicTests.swift
+++ b/Tests/LidlessTests/SharedLogicTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+
+final class SharedLogicTests: XCTestCase {
+
+    // MARK: PowerParsers.isSleepDisabled
+
+    func testSleepDisabledTrue() {
+        let out = """
+        System-wide power settings:
+         SleepDisabled        1
+        Currently in use:
+         standby              1
+        """
+        XCTAssertTrue(PowerParsers.isSleepDisabled(pmsetG: out))
+    }
+
+    func testSleepDisabledFalse() {
+        let out = """
+        System-wide power settings:
+         SleepDisabled        0
+        """
+        XCTAssertFalse(PowerParsers.isSleepDisabled(pmsetG: out))
+    }
+
+    func testSleepDisabledMissing() {
+        XCTAssertFalse(PowerParsers.isSleepDisabled(pmsetG: "Currently in use:\n standby 1"))
+    }
+
+    // MARK: BatteryParsers
+
+    func testBatteryOnAC() {
+        let out = "Now drawing from 'AC Power'\n -InternalBattery-0 (id=123)\t87%; charging; 0:42 remaining present: true"
+        let info = BatteryParsers.parse(pmsetBatt: out)
+        XCTAssertEqual(info.percent, 87)
+        XCTAssertTrue(info.onAC)
+        XCTAssertEqual(info.source, "AC")
+    }
+
+    func testBatteryOnBattery() {
+        let out = "Now drawing from 'Battery Power'\n -InternalBattery-0 (id=123)\t19%; discharging; 1:05 remaining present: true"
+        let info = BatteryParsers.parse(pmsetBatt: out)
+        XCTAssertEqual(info.percent, 19)
+        XCTAssertFalse(info.onAC)
+        XCTAssertEqual(info.source, "Battery")
+    }
+
+    // MARK: Watchdog
+
+    func testWatchdogFiresAfterTimeout() {
+        let last = Date(timeIntervalSince1970: 1000)
+        let now = Date(timeIntervalSince1970: 1100) // 100s later
+        XCTAssertTrue(Watchdog.shouldAutoRestore(lastHeartbeat: last, now: now, timeout: 90))
+    }
+
+    func testWatchdogQuietWithinTimeout() {
+        let last = Date(timeIntervalSince1970: 1000)
+        let now = Date(timeIntervalSince1970: 1060) // 60s later
+        XCTAssertFalse(Watchdog.shouldAutoRestore(lastHeartbeat: last, now: now, timeout: 90))
+    }
+
+    // MARK: SafetyPolicy
+
+    func testSafetyDisablesOnLowBattery() {
+        let info = BatteryInfo(percent: 15, onAC: false)
+        XCTAssertTrue(SafetyPolicy.shouldDisableForBattery(info, threshold: 20))
+    }
+
+    func testSafetyAllowsOnAC() {
+        let info = BatteryInfo(percent: 5, onAC: true)
+        XCTAssertFalse(SafetyPolicy.shouldDisableForBattery(info, threshold: 20))
+    }
+
+    func testSafetyAllowsAboveThreshold() {
+        let info = BatteryInfo(percent: 80, onAC: false)
+        XCTAssertFalse(SafetyPolicy.shouldDisableForBattery(info, threshold: 20))
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -4,12 +4,25 @@ options:
   deploymentTarget:
     macOS: "13.0"
   createIntermediateGroups: true
+
+settings:
+  base:
+    SWIFT_VERSION: "5.0"
+    DEVELOPMENT_TEAM: TAFDRXJZSR
+    CODE_SIGN_STYLE: Automatic
+
 targets:
   Lidless:
     type: application
     platform: macOS
     sources:
       - Sources/Lidless
+      - Sources/Shared
+      - path: Resources/com.nghialuong.lidless.helper.plist
+        buildPhase:
+          copyFiles:
+            destination: wrapper
+            subpath: Contents/Library/LaunchDaemons
     info:
       path: Sources/Lidless/Info.plist
       properties:
@@ -25,7 +38,42 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.nghialuong.lidless
         MARKETING_VERSION: "0.1.0"
         CURRENT_PROJECT_VERSION: "1"
-        SWIFT_VERSION: "5.0"
         ENABLE_HARDENED_RUNTIME: YES
-        CODE_SIGN_STYLE: Automatic
-        DEVELOPMENT_TEAM: TAFDRXJZSR
+    dependencies:
+      - target: LidlessHelper
+        copy:
+          destination: executables
+
+  LidlessHelper:
+    type: tool
+    platform: macOS
+    sources:
+      - Sources/Helper
+      - Sources/Shared
+    settings:
+      base:
+        PRODUCT_NAME: LidlessHelper
+        PRODUCT_BUNDLE_IDENTIFIER: com.nghialuong.lidless.helper
+        ENABLE_HARDENED_RUNTIME: YES
+
+  LidlessTests:
+    type: bundle.unit-test
+    platform: macOS
+    sources:
+      - Tests/LidlessTests
+      - Sources/Shared
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.nghialuong.lidlessTests
+        GENERATE_INFOPLIST_FILE: YES
+
+schemes:
+  Lidless-CI:
+    build:
+      targets:
+        Lidless: all
+        LidlessHelper: all
+        LidlessTests: [test]
+    test:
+      targets:
+        - LidlessTests


### PR DESCRIPTION
## What

Promotes Lidless from the M1 admin-prompt approach to a proper **privileged background helper**, so toggling keep-awake no longer asks for a password every time, and the Mac can never get stuck awake.

## Changes

- **Root daemon `LidlessHelper`** — flips the `SleepDisabled` flag via `pmset` (runs as root, no admin prompt). Served over XPC via `LidlessHelperProtocol`. Embedded in the app bundle (`Contents/MacOS/LidlessHelper`) with its LaunchDaemon plist at `Contents/Library/LaunchDaemons/`.
- **Heartbeat watchdog** in the helper — if the app stops checking in for >90s (crash, force-quit), the helper auto-restores normal sleep. Safety net against a stuck-awake machine.
- **`HelperManager`** (app) — registration/approval via `SMAppService`, `NSXPCConnection` client.
- **`AppState`** — prefers the helper; falls back to the M1 admin-prompt path if the helper isn't installed. Low-battery safety auto-disable (≤20% on battery). 30s heartbeat while active.
- **Pure, unit-tested logic** — `pmset` parsers, watchdog decision, safety policy. **10 tests.**
- **CI** — GitHub Actions: `xcodegen generate` + `xcodebuild test` on macOS.

## Verification

- ✅ `xcodebuild test -scheme Lidless-CI` — build + 10/10 tests pass locally.
- ✅ Bundle layout verified: helper at `Contents/MacOS/LidlessHelper`, daemon plist at `Contents/Library/LaunchDaemons/`.
- ✅ CI runs build+test on every push/PR (this is the green check).

## Not yet verified (needs a signed build on the MacBook)

- Runtime `SMAppService` registration + the System Settings ▸ Login Items approval flow.
- Actual lid-closed behaviour through the helper (the M0 spike already proved the underlying `pmset disablesleep` mechanism works on real Apple Silicon).
- These require Developer ID signing + notarization, which CI intentionally skips (`CODE_SIGNING_ALLOWED=NO`). The admin-prompt fallback keeps the app fully usable meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
