### PR TITLE
M2: safety preferences (charging / thermal / battery) + persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ is the `SleepDisabled` flag in `IOPMrootDomain` (what `sudo pmset -a disableslee
   admin prompt (`osascript ... with administrator privileges`).
 - **M1.5 (next):** privileged helper via `SMAppService` + XPC → password-less, with a
   heartbeat watchdog that auto-clears the flag if the app dies (never get stuck awake).
-- **M2:** safety guards — low-battery auto-disable, "only while charging", thermal note.
+- **M2 (in progress):** safety guards — low-battery auto-disable, "only while charging",
+  thermal auto-pause, persisted preferences. Remaining: app icon + onboarding polish.
 
 ## Build
 

--- a/Sources/Lidless/AppState.swift
+++ b/Sources/Lidless/AppState.swift
@@ -12,19 +12,49 @@ final class AppState: ObservableObject {
     /// True when using the privileged helper; false when on the M1 admin-prompt fallback.
     @Published var usingHelper = false
 
+    /// User-tunable safety preferences (persisted).
+    @Published var settings: SafetySettings = .default
+
     private let helper = HelperManager()
     private let fallback = PowerManager()
     private let battery = BatteryMonitor()
+    private let store = SettingsStore()
     private var batteryTimer: Timer?
     private var heartbeatTimer: Timer?
-    private let lowBatteryThreshold = 20
 
     init() {
+        settings = store.load()
         refreshHelperStatus()
         refreshState()
         refreshBattery()
         batteryTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
             Task { @MainActor in self?.tick() }
+        }
+    }
+
+    // MARK: Settings
+
+    func updateSettings(_ new: SafetySettings) {
+        settings = new
+        store.save(new)
+        evaluateSafety()
+    }
+
+    private func thermalSerious() -> Bool {
+        let state = ProcessInfo.processInfo.thermalState
+        return state == .serious || state == .critical
+    }
+
+    /// Auto-disable keep-awake if current conditions violate the safety policy.
+    func evaluateSafety() {
+        guard isEnabled else { return }
+        let info = battery.read()
+        if let reason = SafetyEvaluator.reasonToDisable(battery: info,
+                                                        thermalSerious: thermalSerious(),
+                                                        settings: settings) {
+            // Pass the reason through so it survives the async helper callback
+            // (which would otherwise clear lastError on success).
+            setEnabled(false, reason: reason)
         }
     }
 
@@ -63,13 +93,26 @@ final class AppState: ObservableObject {
 
     func toggle() { setEnabled(!isEnabled) }
 
-    func setEnabled(_ target: Bool) {
+    /// Set keep-awake. `reason` is shown to the user on a successful change
+    /// (used when an auto-pause disables it); nil clears any prior message.
+    func setEnabled(_ target: Bool, reason: SafetyReason? = nil) {
+        // Refuse to enable if it would immediately violate the safety policy.
+        if target {
+            let info = battery.read()
+            if let blocker = SafetyEvaluator.reasonToDisable(battery: info,
+                                                             thermalSerious: thermalSerious(),
+                                                             settings: settings) {
+                lastError = blocker.message
+                return
+            }
+        }
+        let resultMessage = reason?.message
         if helperInstalled {
             helper.setKeepAwake(target) { [weak self] ok, err in
                 guard let self else { return }
                 if ok {
                     self.isEnabled = target
-                    self.lastError = nil
+                    self.lastError = resultMessage
                     self.manageHeartbeat()
                 } else {
                     self.lastError = err
@@ -80,7 +123,7 @@ final class AppState: ObservableObject {
             do {
                 try fallback.setSleepDisabled(target)
                 isEnabled = target
-                lastError = nil
+                lastError = resultMessage
             } catch {
                 lastError = error.localizedDescription
                 isEnabled = fallback.isSleepDisabled()
@@ -96,7 +139,7 @@ final class AppState: ObservableObject {
         guard isEnabled, helperInstalled else { return }
         helper.heartbeat()
         heartbeatTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
-            self?.helper.heartbeat()
+            Task { @MainActor in self?.helper.heartbeat() }
         }
     }
 
@@ -104,11 +147,7 @@ final class AppState: ObservableObject {
 
     func tick() {
         refreshBattery()
-        let info = battery.read()
-        if isEnabled, SafetyPolicy.shouldDisableForBattery(info, threshold: lowBatteryThreshold) {
-            setEnabled(false)
-            lastError = "Auto-disabled: battery \(info.percent)% on battery power."
-        }
+        evaluateSafety()
     }
 
     func refreshBattery() {

--- a/Sources/Lidless/MenuContent.swift
+++ b/Sources/Lidless/MenuContent.swift
@@ -50,6 +50,46 @@ struct MenuContent: View {
                 Spacer()
             }
 
+            Divider()
+
+            Text("Safety")
+                .font(.caption.bold())
+                .foregroundStyle(.secondary)
+
+            Toggle("Only while charging", isOn: Binding(
+                get: { state.settings.onlyWhileCharging },
+                set: { newValue in
+                    var s = state.settings
+                    s.onlyWhileCharging = newValue
+                    state.updateSettings(s)
+                }
+            ))
+            .toggleStyle(.checkbox)
+            .font(.caption)
+
+            Toggle("Pause when running hot", isOn: Binding(
+                get: { state.settings.pauseOnHighThermal },
+                set: { newValue in
+                    var s = state.settings
+                    s.pauseOnHighThermal = newValue
+                    state.updateSettings(s)
+                }
+            ))
+            .toggleStyle(.checkbox)
+            .font(.caption)
+
+            Stepper(value: Binding(
+                get: { state.settings.lowBatteryThreshold },
+                set: { newValue in
+                    var s = state.settings
+                    s.lowBatteryThreshold = newValue
+                    state.updateSettings(s)
+                }
+            ), in: 5...50, step: 5) {
+                Text("Low-battery cutoff: \(state.settings.lowBatteryThreshold)%")
+                    .font(.caption)
+            }
+
             if let err = state.lastError {
                 Text(err)
                     .font(.caption)

--- a/Sources/Shared/SafetySettings.swift
+++ b/Sources/Shared/SafetySettings.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// User-tunable safety preferences for keep-awake.
+public struct SafetySettings: Equatable {
+    public var lowBatteryThreshold: Int
+    public var onlyWhileCharging: Bool
+    public var pauseOnHighThermal: Bool
+
+    public static let `default` = SafetySettings(
+        lowBatteryThreshold: 20,
+        onlyWhileCharging: false,
+        pauseOnHighThermal: true
+    )
+
+    public init(lowBatteryThreshold: Int, onlyWhileCharging: Bool, pauseOnHighThermal: Bool) {
+        self.lowBatteryThreshold = lowBatteryThreshold
+        self.onlyWhileCharging = onlyWhileCharging
+        self.pauseOnHighThermal = pauseOnHighThermal
+    }
+}
+
+/// Why keep-awake was (or should be) auto-disabled.
+public enum SafetyReason: Equatable {
+    case highThermal
+    case notCharging
+    case lowBattery(Int)
+
+    public var message: String {
+        switch self {
+        case .highThermal:        return "Auto-paused: the Mac is running hot."
+        case .notCharging:        return "Auto-paused: not on charger."
+        case .lowBattery(let p):  return "Auto-paused: battery \(p)% on battery power."
+        }
+    }
+}
+
+/// Pure safety decision. No side effects, fully unit-testable.
+public enum SafetyEvaluator {
+    /// The reason keep-awake should be disabled given current conditions, or
+    /// `nil` if it's safe to stay awake. Checked in priority order:
+    /// thermal first (hardware protection), then charging policy, then battery.
+    public static func reasonToDisable(battery: BatteryInfo,
+                                       thermalSerious: Bool,
+                                       settings: SafetySettings) -> SafetyReason? {
+        if settings.pauseOnHighThermal && thermalSerious {
+            return .highThermal
+        }
+        if settings.onlyWhileCharging && !battery.onAC {
+            return .notCharging
+        }
+        if !battery.onAC && battery.percent <= settings.lowBatteryThreshold {
+            return .lowBattery(battery.percent)
+        }
+        return nil
+    }
+}

--- a/Sources/Shared/SettingsStore.swift
+++ b/Sources/Shared/SettingsStore.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Persists SafetySettings in UserDefaults. Returns `.default` until the user
+/// has saved at least once (so first launch uses sane defaults, not zeros).
+public struct SettingsStore {
+    private let defaults: UserDefaults
+
+    private enum Key {
+        static let lowBattery   = "lowBatteryThreshold"
+        static let onlyCharging = "onlyWhileCharging"
+        static let pauseThermal = "pauseOnHighThermal"
+        static let seeded       = "settingsSeeded"
+    }
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public func load() -> SafetySettings {
+        guard defaults.bool(forKey: Key.seeded) else { return .default }
+        return SafetySettings(
+            lowBatteryThreshold: defaults.integer(forKey: Key.lowBattery),
+            onlyWhileCharging: defaults.bool(forKey: Key.onlyCharging),
+            pauseOnHighThermal: defaults.bool(forKey: Key.pauseThermal)
+        )
+    }
+
+    public func save(_ settings: SafetySettings) {
+        defaults.set(settings.lowBatteryThreshold, forKey: Key.lowBattery)
+        defaults.set(settings.onlyWhileCharging, forKey: Key.onlyCharging)
+        defaults.set(settings.pauseOnHighThermal, forKey: Key.pauseThermal)
+        defaults.set(true, forKey: Key.seeded)
+    }
+}

--- a/Tests/LidlessTests/SafetyEvaluatorTests.swift
+++ b/Tests/LidlessTests/SafetyEvaluatorTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+
+final class SafetyEvaluatorTests: XCTestCase {
+
+    private let defaults = SafetySettings.default
+
+    func testSafeWhenChargingAndCool() {
+        let info = BatteryInfo(percent: 50, onAC: true)
+        XCTAssertNil(SafetyEvaluator.reasonToDisable(battery: info, thermalSerious: false, settings: defaults))
+    }
+
+    func testThermalTakesPriority() {
+        let info = BatteryInfo(percent: 100, onAC: true)
+        XCTAssertEqual(
+            SafetyEvaluator.reasonToDisable(battery: info, thermalSerious: true, settings: defaults),
+            .highThermal
+        )
+    }
+
+    func testThermalIgnoredWhenSettingOff() {
+        var s = defaults
+        s.pauseOnHighThermal = false
+        let info = BatteryInfo(percent: 100, onAC: true)
+        XCTAssertNil(SafetyEvaluator.reasonToDisable(battery: info, thermalSerious: true, settings: s))
+    }
+
+    func testOnlyWhileChargingTriggersOnBattery() {
+        var s = defaults
+        s.onlyWhileCharging = true
+        let info = BatteryInfo(percent: 90, onAC: false)
+        XCTAssertEqual(
+            SafetyEvaluator.reasonToDisable(battery: info, thermalSerious: false, settings: s),
+            .notCharging
+        )
+    }
+
+    func testLowBatteryTriggers() {
+        let info = BatteryInfo(percent: 15, onAC: false)
+        XCTAssertEqual(
+            SafetyEvaluator.reasonToDisable(battery: info, thermalSerious: false, settings: defaults),
+            .lowBattery(15)
+        )
+    }
+
+    func testChargingOverridesLowBattery() {
+        let info = BatteryInfo(percent: 5, onAC: true)
+        XCTAssertNil(SafetyEvaluator.reasonToDisable(battery: info, thermalSerious: false, settings: defaults))
+    }
+
+    func testReasonMessages() {
+        XCTAssertEqual(SafetyReason.highThermal.message, "Auto-paused: the Mac is running hot.")
+        XCTAssertEqual(SafetyReason.notCharging.message, "Auto-paused: not on charger.")
+        XCTAssertEqual(SafetyReason.lowBattery(12).message, "Auto-paused: battery 12% on battery power.")
+    }
+
+    // MARK: SettingsStore
+
+    func testSettingsStoreDefaultsWhenUnseeded() {
+        let suite = "test.lidless.unseeded"
+        let d = UserDefaults(suiteName: suite)!
+        d.removePersistentDomain(forName: suite)
+        XCTAssertEqual(SettingsStore(defaults: d).load(), .default)
+    }
+
+    func testSettingsStoreRoundTrip() {
+        let suite = "test.lidless.roundtrip"
+        let d = UserDefaults(suiteName: suite)!
+        d.removePersistentDomain(forName: suite)
+        let store = SettingsStore(defaults: d)
+        var s = SafetySettings.default
+        s.onlyWhileCharging = true
+        s.pauseOnHighThermal = false
+        s.lowBatteryThreshold = 35
+        store.save(s)
+        XCTAssertEqual(store.load(), s)
+        d.removePersistentDomain(forName: suite)
+    }
+}


### PR DESCRIPTION
## What

Adds the M2 **safety & preferences** layer on top of M1.5. Stacked on top of #1 — base will auto-retarget to `main` once #1 merges.

## Changes

- **`SafetyEvaluator`** (pure) — decides when to auto-pause keep-awake, in priority order:
  1. **Pause when running hot** — `ProcessInfo.thermalState` is `serious`/`critical`.
  2. **Only while charging** — off AC power (opt-in).
  3. **Low-battery cutoff** — on battery at/below the threshold (default 20%).
- **`SafetySettings` + `SettingsStore`** — user prefs persisted to UserDefaults (seeded-flag avoids the first-launch "0" trap).
- **`AppState`** — refuses to enable when conditions are unsafe; re-evaluates every 30s and on every settings change; the auto-pause reason now survives the async helper callback (caught in self-review).
- **`MenuContent`** — new **Safety** section: "Only while charging" + "Pause when running hot" toggles, and a low-battery cutoff stepper (5–50%).

## Verification

- ✅ `xcodebuild test -scheme Lidless-CI` — build + **19/19 tests** pass locally (CLI only, no Xcode).
- ✅ Independent code review pass; the one 🔴 it found (lastError clobbering on the async disable path) is fixed in this PR.
- ✅ CI (GitHub Actions) runs build+test on push/PR.

## Notes / deferred

- App icon + onboarding polish still pending (low-value to do headlessly; benefit from a visual check).
- Runtime behaviour of the helper still needs a signed build on the MacBook (unchanged from #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
