### PR TITLE
Add explicit Lidless scheme for release.sh / Release builds

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -71,6 +71,14 @@ targets:
         GENERATE_INFOPLIST_FILE: YES
 
 schemes:
+  Lidless:
+    build:
+      targets:
+        Lidless: all
+    run:
+      config: Debug
+    archive:
+      config: Release
   Lidless-CI:
     build:
       targets:


### PR DESCRIPTION
Generates a shared `Lidless` scheme (run=Debug, archive=Release) alongside `Lidless-CI`. Required because `scripts/release.sh` archives with `-scheme Lidless`, which didn't exist. Verified: `xcodebuild build -scheme Lidless -configuration Release` succeeds; tests still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)