### PR TITLE
Fix "Open Login Items to approve" doing nothing

### DIFF
--- a/Sources/Lidless/AppState.swift
+++ b/Sources/Lidless/AppState.swift
@@ -87,6 +87,13 @@ final class AppState: ObservableObject {
     }
 
     func installHelper() {
+        // If the daemon is already registered and just awaiting approval, don't
+        // re-register (that throws once pending and would swallow the open) —
+        // just take the user to Login Items.
+        if helper.requiresApproval {
+            openLoginItems()
+            return
+        }
         do {
             try helper.register()
             refreshHelperStatus()
@@ -99,6 +106,15 @@ final class AppState: ObservableObject {
         } catch {
             lastError = error.localizedDescription
         }
+    }
+
+    /// Open System Settings ▸ Login Items so the user can approve the helper.
+    /// Kept separate from `installHelper()` so re-registration can never swallow
+    /// the open.
+    func openLoginItems() {
+        lastError = "Approve Lidless in System Settings ▸ Login Items."
+        helper.openLoginItemsSettings()
+        refreshHelperStatus()
     }
 
     // MARK: State

--- a/Sources/Lidless/HelperManager.swift
+++ b/Sources/Lidless/HelperManager.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import ServiceManagement
 
@@ -25,6 +26,12 @@ final class HelperManager {
 
     func openLoginItemsSettings() {
         SMAppService.openSystemSettingsLoginItems()
+        // Fallback: the SMAppService call silently no-ops for LSUIElement apps
+        // or when System Settings is already running in the background, so also
+        // open the Login Items pane by URL, which brings Settings to the front.
+        if let url = URL(string: "x-apple.systempreferences:com.apple.LoginItems-Settings.extension") {
+            NSWorkspace.shared.open(url)
+        }
     }
 
     // MARK: XPC


### PR DESCRIPTION
## Problem

Clicking **"Open Login Items to approve"** did nothing — System Settings never opened, so the privileged helper could never be approved. The app stayed on the `osascript` admin-prompt fallback, asking for a password on every enable/disable.

## Root cause

Two bugs in the approval flow:

1. **`installHelper()` re-registered when already pending.** Once the daemon is in `.requiresApproval`, calling `helper.register()` again throws, so the `catch` swallowed control before `openLoginItemsSettings()` ran.
2. **`SMAppService.openSystemSettingsLoginItems()` silently no-ops** for `LSUIElement` (menu-bar accessory) apps.

## Fix

- `installHelper()` short-circuits to opening Login Items when status is `.requiresApproval`, instead of re-registering. Extracted `openLoginItems()`.
- Added a URL fallback `x-apple.systempreferences:com.apple.LoginItems-Settings.extension` that reliably brings the Login Items pane to the front.

## Test

1. Launch the app, click **Install background helper** → settings open.
2. Approve **Lidless** in Login Items.
3. Enable/disable keep-awake → no longer prompts for a password (uses the helper over XPC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)