### PR TITLE
Add auto-off timer (turn off keep-awake after N minutes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ so coding agents (Claude Code, Codex, etc.) keep working while you move around.
 - Privileged background **helper** (`SMAppService`) so toggling never asks for a password.
 - **Watchdog**: if the app crashes or is force-quit, the helper auto-restores normal sleep — the Mac can't get stuck awake.
 - **Safety guards**: pause when running hot, only-while-charging, and a low-battery cutoff.
+- **Auto-off timer**: optionally turn keep-awake off after 15 min – 4 hours, with a live countdown.
 - **Launch at login**, and a clean menu with battery/power status.
 
 ## How it works

--- a/Sources/Lidless/AppState.swift
+++ b/Sources/Lidless/AppState.swift
@@ -18,6 +18,14 @@ final class AppState: ObservableObject {
     /// Launch-at-login state (the app itself).
     @Published var launchAtLogin = false
 
+    /// Auto-off timer: minutes after which keep-awake turns itself off
+    /// (`0` = never). Persisted.
+    @Published var autoOffMinutes = 0
+    /// When the active auto-off timer will fire; nil when not counting down.
+    @Published var autoOffDeadline: Date?
+    /// Human countdown (e.g. `1:05:09`) shown while a timer is active.
+    @Published var autoOffRemaining = ""
+
     private let helper = HelperManager()
     private let fallback = PowerManager()
     private let battery = BatteryMonitor()
@@ -30,9 +38,11 @@ final class AppState: ObservableObject {
     }
     private var batteryTimer: Timer?
     private var heartbeatTimer: Timer?
+    private var autoOffTimer: Timer?
 
     init() {
         settings = store.load()
+        autoOffMinutes = store.loadAutoOffMinutes()
         launchAtLogin = loginItem.isEnabled
         refreshHelperStatus()
         refreshState()
@@ -48,6 +58,14 @@ final class AppState: ObservableObject {
         settings = new
         store.save(new)
         evaluateSafety()
+    }
+
+    /// Change the auto-off duration. Re-arms (or cancels) the live timer when
+    /// keep-awake is currently on.
+    func setAutoOffMinutes(_ minutes: Int) {
+        autoOffMinutes = minutes
+        store.saveAutoOffMinutes(minutes)
+        if isEnabled { armAutoOff() } else { cancelAutoOff() }
     }
 
     func setLaunchAtLogin(_ enabled: Bool) {
@@ -72,9 +90,9 @@ final class AppState: ObservableObject {
         if let reason = SafetyEvaluator.reasonToDisable(battery: info,
                                                         thermalSerious: thermalSerious(),
                                                         settings: settings) {
-            // Pass the reason through so it survives the async helper callback
+            // Pass the message through so it survives the async helper callback
             // (which would otherwise clear lastError on success).
-            setEnabled(false, reason: reason)
+            setEnabled(false, note: reason.message)
         }
     }
 
@@ -129,9 +147,10 @@ final class AppState: ObservableObject {
 
     func toggle() { setEnabled(!isEnabled) }
 
-    /// Set keep-awake. `reason` is shown to the user on a successful change
-    /// (used when an auto-pause disables it); nil clears any prior message.
-    func setEnabled(_ target: Bool, reason: SafetyReason? = nil) {
+    /// Set keep-awake. `note` is shown to the user on a successful change
+    /// (used when an auto-pause or the auto-off timer disables it); nil clears
+    /// any prior message.
+    func setEnabled(_ target: Bool, note: String? = nil) {
         // Refuse to enable if it would immediately violate the safety policy.
         if target {
             let info = battery.read()
@@ -142,7 +161,7 @@ final class AppState: ObservableObject {
                 return
             }
         }
-        let resultMessage = reason?.message
+        let resultMessage = note
         if helperInstalled {
             helper.setKeepAwake(target) { [weak self] ok, err in
                 guard let self else { return }
@@ -150,6 +169,7 @@ final class AppState: ObservableObject {
                     self.isEnabled = target
                     self.lastError = resultMessage
                     self.manageHeartbeat()
+                    self.updateAutoOff(for: target)
                 } else {
                     self.lastError = err
                     self.refreshState()
@@ -160,6 +180,7 @@ final class AppState: ObservableObject {
                 try fallback.setSleepDisabled(target)
                 isEnabled = target
                 lastError = resultMessage
+                updateAutoOff(for: target)
             } catch {
                 lastError = error.localizedDescription
                 isEnabled = fallback.isSleepDisabled()
@@ -177,6 +198,49 @@ final class AppState: ObservableObject {
         heartbeatTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
             Task { @MainActor in self?.helper.heartbeat() }
         }
+    }
+
+    // MARK: Auto-off timer
+
+    /// Arm when keep-awake turns on, cancel when it turns off.
+    private func updateAutoOff(for enabled: Bool) {
+        if enabled { armAutoOff() } else { cancelAutoOff() }
+    }
+
+    private func armAutoOff() {
+        cancelAutoOff()
+        guard isEnabled, autoOffMinutes > 0 else { return }
+        let deadline = AutoOff.deadline(from: Date(), minutes: autoOffMinutes)
+        autoOffDeadline = deadline
+        refreshAutoOffRemaining()
+        // One repeating timer drives both the countdown label and the firing,
+        // and only runs while a timer is actually armed.
+        autoOffTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.autoOffTick() }
+        }
+    }
+
+    private func cancelAutoOff() {
+        autoOffTimer?.invalidate()
+        autoOffTimer = nil
+        autoOffDeadline = nil
+        autoOffRemaining = ""
+    }
+
+    private func autoOffTick() {
+        guard let deadline = autoOffDeadline else { return }
+        if AutoOff.isExpired(deadline: deadline, now: Date()) {
+            let minutes = autoOffMinutes
+            cancelAutoOff()
+            setEnabled(false, note: "Auto-off: \(AutoOff.optionLabel(minutes: minutes)) elapsed.")
+        } else {
+            refreshAutoOffRemaining()
+        }
+    }
+
+    private func refreshAutoOffRemaining() {
+        guard let deadline = autoOffDeadline else { autoOffRemaining = ""; return }
+        autoOffRemaining = AutoOff.formatCountdown(AutoOff.remaining(deadline: deadline, now: Date()))
     }
 
     // MARK: Battery + safety guard

--- a/Sources/Lidless/MenuContent.swift
+++ b/Sources/Lidless/MenuContent.swift
@@ -79,6 +79,31 @@ struct MenuContent: View {
                 Text("Low-battery cutoff: \(state.settings.lowBatteryThreshold)%").font(.caption)
             }
 
+            Divider()
+
+            Text("Auto-off timer").font(.caption.bold()).foregroundStyle(.secondary)
+
+            Picker(selection: Binding(
+                get: { state.autoOffMinutes },
+                set: { state.setAutoOffMinutes($0) }
+            )) {
+                Text("Never").tag(0)
+                ForEach(AutoOff.presetMinutes, id: \.self) { m in
+                    Text(AutoOff.optionLabel(minutes: m)).tag(m)
+                }
+            } label: {
+                Text("Turn off after").font(.caption)
+            }
+            .pickerStyle(.menu).font(.caption)
+
+            if state.isEnabled, !state.autoOffRemaining.isEmpty {
+                HStack(spacing: 6) {
+                    Image(systemName: "timer").foregroundStyle(.secondary)
+                    Text("Turning off in \(state.autoOffRemaining)")
+                        .font(.caption2).foregroundStyle(.secondary)
+                }
+            }
+
             if let err = state.lastError {
                 Text(err).font(.caption).foregroundStyle(.red)
                     .fixedSize(horizontal: false, vertical: true)

--- a/Sources/Shared/AutoOff.swift
+++ b/Sources/Shared/AutoOff.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Auto-off timer logic (pure, unit-testable).
+///
+/// Keep-awake is a convenience, not a safety mechanism, so the countdown lives
+/// in the app — if the app dies the helper watchdog restores sleep anyway.
+public enum AutoOff {
+    /// Selectable durations (minutes). `0` means "no auto-off" (stay on until off).
+    public static let presetMinutes = [15, 30, 60, 120, 240]
+
+    /// When a timer started `minutes` ago from `start` should fire.
+    public static func deadline(from start: Date, minutes: Int) -> Date {
+        start.addingTimeInterval(TimeInterval(minutes) * 60)
+    }
+
+    /// Seconds left until `deadline` (never negative).
+    public static func remaining(deadline: Date, now: Date) -> TimeInterval {
+        max(0, deadline.timeIntervalSince(now))
+    }
+
+    /// True once `now` has reached or passed `deadline`.
+    public static func isExpired(deadline: Date, now: Date) -> Bool {
+        now >= deadline
+    }
+
+    /// Countdown like `1:05:09` (with hours) or `9:42` (under an hour).
+    public static func formatCountdown(_ seconds: TimeInterval) -> String {
+        let total = Int(seconds.rounded())
+        let h = total / 3600
+        let m = (total % 3600) / 60
+        let s = total % 60
+        return h > 0
+            ? String(format: "%d:%02d:%02d", h, m, s)
+            : String(format: "%d:%02d", m, s)
+    }
+
+    /// Menu label for a duration, e.g. `15 min`, `1 hour`, `2 hours`.
+    public static func optionLabel(minutes: Int) -> String {
+        guard minutes % 60 == 0 else { return "\(minutes) min" }
+        let h = minutes / 60
+        return h == 1 ? "1 hour" : "\(h) hours"
+    }
+}

--- a/Sources/Shared/SettingsStore.swift
+++ b/Sources/Shared/SettingsStore.swift
@@ -10,6 +10,7 @@ public struct SettingsStore {
         static let onlyCharging = "onlyWhileCharging"
         static let pauseThermal = "pauseOnHighThermal"
         static let seeded       = "settingsSeeded"
+        static let autoOff      = "autoOffMinutes"
     }
 
     public init(defaults: UserDefaults = .standard) {
@@ -30,5 +31,14 @@ public struct SettingsStore {
         defaults.set(settings.onlyWhileCharging, forKey: Key.onlyCharging)
         defaults.set(settings.pauseOnHighThermal, forKey: Key.pauseThermal)
         defaults.set(true, forKey: Key.seeded)
+    }
+
+    /// Auto-off duration in minutes (`0` = no auto-off). Defaults to 0.
+    public func loadAutoOffMinutes() -> Int {
+        defaults.integer(forKey: Key.autoOff)
+    }
+
+    public func saveAutoOffMinutes(_ minutes: Int) {
+        defaults.set(minutes, forKey: Key.autoOff)
     }
 }

--- a/Tests/LidlessTests/SharedLogicTests.swift
+++ b/Tests/LidlessTests/SharedLogicTests.swift
@@ -74,4 +74,46 @@ final class SharedLogicTests: XCTestCase {
         let info = BatteryInfo(percent: 80, onAC: false)
         XCTAssertFalse(SafetyPolicy.shouldDisableForBattery(info, threshold: 20))
     }
+
+    // MARK: AutoOff
+
+    func testAutoOffDeadlineIsStartPlusMinutes() {
+        let start = Date(timeIntervalSince1970: 1000)
+        XCTAssertEqual(AutoOff.deadline(from: start, minutes: 30),
+                       Date(timeIntervalSince1970: 1000 + 1800))
+    }
+
+    func testAutoOffRemainingClampsToZero() {
+        let deadline = Date(timeIntervalSince1970: 1000)
+        let now = Date(timeIntervalSince1970: 1100) // already past
+        XCTAssertEqual(AutoOff.remaining(deadline: deadline, now: now), 0)
+    }
+
+    func testAutoOffRemainingCountsDown() {
+        let deadline = Date(timeIntervalSince1970: 1100)
+        let now = Date(timeIntervalSince1970: 1040)
+        XCTAssertEqual(AutoOff.remaining(deadline: deadline, now: now), 60)
+    }
+
+    func testAutoOffExpiry() {
+        let deadline = Date(timeIntervalSince1970: 1000)
+        XCTAssertTrue(AutoOff.isExpired(deadline: deadline, now: deadline))
+        XCTAssertTrue(AutoOff.isExpired(deadline: deadline, now: Date(timeIntervalSince1970: 1001)))
+        XCTAssertFalse(AutoOff.isExpired(deadline: deadline, now: Date(timeIntervalSince1970: 999)))
+    }
+
+    func testAutoOffCountdownFormatting() {
+        XCTAssertEqual(AutoOff.formatCountdown(30), "0:30")
+        XCTAssertEqual(AutoOff.formatCountdown(582), "9:42")
+        XCTAssertEqual(AutoOff.formatCountdown(3909), "1:05:09")
+        XCTAssertEqual(AutoOff.formatCountdown(0), "0:00")
+    }
+
+    func testAutoOffOptionLabels() {
+        XCTAssertEqual(AutoOff.optionLabel(minutes: 15), "15 min")
+        XCTAssertEqual(AutoOff.optionLabel(minutes: 30), "30 min")
+        XCTAssertEqual(AutoOff.optionLabel(minutes: 60), "1 hour")
+        XCTAssertEqual(AutoOff.optionLabel(minutes: 120), "2 hours")
+        XCTAssertEqual(AutoOff.optionLabel(minutes: 240), "4 hours")
+    }
 }


### PR DESCRIPTION
## What

Adds an optional **auto-off timer**: keep-awake turns itself off after a chosen duration (**15 min · 30 min · 1 / 2 / 4 hours**, or **Never**), with a live countdown in the menu.

This closes the one gap surfaced when comparing Lidless to the ["how to make a Mac not sleep" guide](https://docs.kanaries.net/articles/how-to-make-mac-not-sleep) and [Macchiato](https://github.com/ObservedObserver/Macchiato): everything else (`pmset disablesleep` for lid-closed, menu toggle, helper approval, watchdog, safety guards) was already covered — only `caffeinate`'s `-t <duration>` "stay awake for N then stop" had no equivalent.

## How

- **`Sources/Shared/AutoOff.swift`** — pure, unit-tested logic: `deadline`, `remaining` (clamped ≥ 0), `isExpired`, `formatCountdown` (`1:05:09` / `9:42`), `optionLabel`, and the preset list.
- **`AppState`** — persisted `autoOffMinutes`; a single 1 s timer that both updates the countdown label and calls `setEnabled(false)` at the deadline. Armed when keep-awake turns on, cancelled when it turns off, re-armed when the duration changes mid-session.
- **`setEnabled(reason:)` → `setEnabled(note:)`** — generalized so both safety auto-pauses and the auto-off timer can show a status message.
- **`MenuContent`** — "Turn off after" picker + a live "Turning off in m:ss" line.

### Design note
The timer lives **app-side on purpose**. Auto-off is a convenience, not a safety mechanism — if the app dies, the root helper's existing 90 s watchdog restores normal sleep regardless. No protocol/helper changes needed.

## Testing

- 6 new `AutoOff` unit tests (deadline, clamping, expiry, formatting, labels).
- `xcodebuild test -scheme Lidless-CI` → **25/25 pass**.
- `xcodebuild build -scheme Lidless` → **BUILD SUCCEEDED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)