### PR TITLE
Prepare repo for public release (MIT license, SECURITY.md, docs)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Nghia Luong
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A tiny macOS menu-bar app that keeps your Mac running **even with the lid closed** —
 so coding agents (Claude Code, Codex, etc.) keep working while you move around.
 
-> Status: **private / WIP**. Open-source decision not made yet — no license file on purpose.
+> Open source under the [MIT License](LICENSE).
 
 ## Features
 
@@ -42,7 +42,12 @@ The `.xcodeproj` is gitignored — `project.yml` is the source of truth.
 
 ## App icon
 
-The icon (an open eye — the lid that never closes) is generated from a single master:
+The app icon and the menu-bar glyphs are committed assets under
+`Resources/Assets.xcassets/` (`AppIcon.appiconset` plus the `MenubarLaptop` /
+`MenubarLaptopActive` template imagesets that mark keep-awake off / on).
+
+`scripts/make_iconset.sh` is kept as a helper for regenerating an icon set from a
+single master if you want to swap the artwork:
 
 ```bash
 bash scripts/make_iconset.sh   # renders icon + emits Assets.xcassets/AppIcon.appiconset
@@ -62,10 +67,16 @@ Signed + notarized DMG (needs a Developer ID cert + a notarytool keychain profil
 - **M1 / M1.5** — menu-bar app + privileged helper + XPC + watchdog. ✅
 - **M2** — safety preferences (thermal / charging / battery) + persistence. ✅
 - **App complete** — icon, launch-at-login, onboarding, About, release pipeline. ✅
-- **Later** — Sparkle auto-update, signed runtime verification on device, open-source/license call.
+- **Later** — Sparkle auto-update, signed runtime verification on device.
 
 ## Safety
 
 Running with the lid closed under heavy load can heat the machine and drain the battery.
 Keep it plugged in and ventilated. The safety guards auto-pause on heat / low battery,
 and a reboot always resets the underlying flag.
+
+To report a security issue, see [SECURITY.md](SECURITY.md).
+
+## License
+
+[MIT](LICENSE) © 2026 Nghia Luong

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported versions
+
+Lidless is a small project; security fixes land on the latest `main` and the most
+recent release. Please test against the latest code before reporting.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Report privately via GitHub's **Security Advisories** — go to the repository's
+**Security** tab → **Report a vulnerability**. If you can't use that, email
+**nghialt01146@gmail.com** instead.
+
+Please include steps to reproduce, the macOS version, and the impact you observed.
+I'll acknowledge as soon as I can and keep you posted on a fix.
+
+## Security-relevant surface
+
+Lidless is not sandboxed and installs a **privileged background helper** to do its job,
+so a few areas matter more than usual:
+
+- **Root LaunchDaemon** (`LidlessHelper`) registered via `SMAppService`. It runs as
+  root and toggles the macOS `SleepDisabled` flag (`IOPMrootDomain`).
+- **XPC interface** (`LidlessHelperProtocol`) between the menu-bar app and the helper —
+  the only channel the app uses to change power state.
+- **Heartbeat watchdog**: if the app stops checking in (>90s), the helper restores
+  normal sleep on its own, so the Mac can't get stuck awake after a crash.
+- **Admin-prompt fallback** (`PowerManager`) shells out to `pmset` via `osascript`
+  with administrator privileges when the helper isn't installed.
+
+Issues in any of these (privilege escalation, unauthorized XPC use, the watchdog
+failing to restore sleep) are the most valuable to report.

--- a/Sources/Lidless/PowerManager.swift
+++ b/Sources/Lidless/PowerManager.swift
@@ -2,12 +2,13 @@ import Foundation
 
 /// Controls the macOS `SleepDisabled` flag (IOPMrootDomain).
 ///
-/// M1 implementation shells out to `pmset -a disablesleep` via `osascript`
-/// with administrator privileges, so toggling prompts for the admin password.
+/// This is the **fallback** path, used only when the privileged helper isn't
+/// installed: it shells out to `pmset -a disablesleep` via `osascript` with
+/// administrator privileges, so toggling prompts for the admin password.
 ///
-/// TODO (M1.5): replace with a privileged helper installed via `SMAppService`
-/// that sets the flag over XPC — password-less, plus a heartbeat watchdog that
-/// auto-clears the flag if the app dies (so the Mac can never get stuck awake).
+/// The primary path is `HelperManager`, which sets the flag over XPC through a
+/// root helper installed via `SMAppService` — password-less, plus a heartbeat
+/// watchdog that auto-clears the flag if the app dies.
 struct PowerManager {
 
     /// Read the current `SleepDisabled` flag from `pmset -g`.


### PR DESCRIPTION
Pre-public hygiene pass. A three-part audit (secrets, open-source readiness, git history) found **no real secrets** — no keys, passwords, certificates, or committed build artifacts; `.gitignore` and CI are clean.

## Changes
- **Add `LICENSE`** — MIT, © 2026 Nghia Luong.
- **Add `SECURITY.md`** — private vulnerability reporting (GitHub Security Advisories + email fallback), plus notes on the security-relevant surface (root LaunchDaemon via `SMAppService`, XPC interface, heartbeat watchdog, admin-prompt fallback).
- **README**: mark the project open source under MIT; fix the app-icon section (it claimed an "open eye generated from a master" — now describes the committed `AppIcon.appiconset` + `MenubarLaptop*` imagesets); drop the resolved open-source milestone; add a License section.
- **`PowerManager.swift`**: reword a stale `TODO (M1.5)` — the privileged helper exists; `PowerManager` is the admin-prompt fallback. Comment only, no logic change.

## Decisions (by owner)
- Personal email in commit history and Apple Team ID (`TAFDRXJZSR`, not a secret) intentionally left as-is — no history rewrite.

## Verification
- `xcodebuild test -scheme Lidless-CI` → **25 tests pass**.
- Release build succeeds.

After merge: flip the GitHub repo to **Public** in settings (manual step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)