### PR TITLE
Add first-run onboarding flow

### DIFF
--- a/Sources/Lidless/AppState.swift
+++ b/Sources/Lidless/AppState.swift
@@ -30,11 +30,15 @@ final class AppState: ObservableObject {
     /// Human countdown (e.g. `1:05:09`) shown while a timer is active.
     @Published var autoOffRemaining = ""
 
+    /// Whether the user has finished first-run onboarding (persisted).
+    @Published var onboardingComplete = false
+
     private let helper = HelperManager()
     private let fallback = PowerManager()
     private let battery = BatteryMonitor()
     private let store = SettingsStore()
     private let loginItem = LoginItemManager()
+    private lazy var onboarding = OnboardingController(state: self)
 
     /// Marketing version shown in the menu.
     var appVersion: String {
@@ -47,6 +51,7 @@ final class AppState: ObservableObject {
     init() {
         settings = store.load()
         autoOffMinutes = store.loadAutoOffMinutes()
+        onboardingComplete = store.loadOnboardingComplete()
         launchAtLogin = loginItem.isEnabled
         refreshHelperStatus()
         refreshState()
@@ -54,6 +59,28 @@ final class AppState: ObservableObject {
         batteryTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
             Task { @MainActor in self?.tick() }
         }
+        // First launch: show onboarding once. Persist the flag now so closing it
+        // early won't re-nag on the next launch. Present on the next runloop tick
+        // so the app is fully up before we open a window.
+        if !onboardingComplete {
+            onboardingComplete = true
+            store.saveOnboardingComplete(true)
+            DispatchQueue.main.async { [weak self] in self?.showOnboarding() }
+        }
+    }
+
+    // MARK: Onboarding
+
+    /// Present the first-run setup window (also reachable from Settings).
+    func showOnboarding() {
+        onboarding.show()
+    }
+
+    /// Mark onboarding done, persist it, and close the window.
+    func completeOnboarding() {
+        onboardingComplete = true
+        store.saveOnboardingComplete(true)
+        onboarding.close()
     }
 
     // MARK: Settings

--- a/Sources/Lidless/OnboardingController.swift
+++ b/Sources/Lidless/OnboardingController.swift
@@ -1,0 +1,46 @@
+import AppKit
+import SwiftUI
+
+/// Hosts the first-run onboarding flow in a standalone window.
+///
+/// Lidless is an `LSUIElement` menu-bar app with no Dock presence, so auto-
+/// presenting and focusing a window from a SwiftUI `Window` scene is unreliable.
+/// A plain AppKit `NSWindow` wrapping the SwiftUI `OnboardingView` gives precise
+/// control over showing, centering, focusing, and closing — and mirrors how the
+/// Settings window already surfaces.
+@MainActor
+final class OnboardingController {
+    private weak var state: AppState?
+    private var window: NSWindow?
+
+    init(state: AppState) {
+        self.state = state
+    }
+
+    /// Show the window, building it on first use and reusing it afterwards so we
+    /// never stack duplicates.
+    func show() {
+        guard let state else { return }
+
+        if window == nil {
+            let root = OnboardingView().environmentObject(state)
+            let hosting = NSHostingController(rootView: root)
+            let win = NSWindow(contentViewController: hosting)
+            win.title = "Welcome to Lidless"
+            win.styleMask = [.titled, .closable, .fullSizeContentView]
+            win.titlebarAppearsTransparent = true
+            win.isMovableByWindowBackground = true
+            win.isReleasedWhenClosed = false
+            win.center()
+            window = win
+        }
+
+        NSApp.activate(ignoringOtherApps: true)
+        window?.makeKeyAndOrderFront(nil)
+        window?.center()
+    }
+
+    func close() {
+        window?.close()
+    }
+}

--- a/Sources/Lidless/OnboardingView.swift
+++ b/Sources/Lidless/OnboardingView.swift
@@ -1,0 +1,195 @@
+import SwiftUI
+
+/// First-run setup walkthrough. Explains what Lidless does and walks the user
+/// through the one optional system step — installing the background helper —
+/// then hands off to the menu bar. Surfaces existing `AppState` flows only; it
+/// introduces no new permission logic.
+struct OnboardingView: View {
+    @EnvironmentObject var state: AppState
+    @State private var step = 0
+
+    private let lastStep = 3
+
+    var body: some View {
+        VStack(spacing: 0) {
+            stepContent
+                .padding(.horizontal, 36)
+                .padding(.top, 36)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+
+            Divider()
+
+            footer
+                .padding(.horizontal, 24)
+                .padding(.vertical, 16)
+        }
+        .frame(width: 460, height: 560)
+    }
+
+    // MARK: Steps
+
+    @ViewBuilder
+    private var stepContent: some View {
+        switch step {
+        case 0:  welcomeStep
+        case 1:  howItWorksStep
+        case 2:  helperStep
+        default: doneStep
+        }
+    }
+
+    private var welcomeStep: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            if let icon = NSApp.applicationIconImage {
+                Image(nsImage: icon)
+                    .resizable()
+                    .frame(width: 88, height: 88)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
+            Text("Welcome to Lidless")
+                .font(.largeTitle.weight(.semibold))
+            Text("Keep your Mac awake — even with the lid closed.")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+            Text("Perfect for letting coding agents, downloads, or builds keep running while you close the lid and carry your Mac around. `caffeinate` can't do this — Lidless can.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var howItWorksStep: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            header(symbol: "bolt.fill", title: "How it works")
+            VStack(alignment: .leading, spacing: 16) {
+                bullet("macbook", "Overrides the lid-close sleep that normally stops everything when you shut the lid.")
+                bullet("thermometer.medium", "Auto-pauses if the Mac runs hot or the battery runs low — so it stays safe unattended.")
+                bullet("shield.lefthalf.filled", "A watchdog restores normal sleep if Lidless ever quits or crashes, so your Mac can never get stuck awake.")
+            }
+            Label("Keep your Mac plugged in and ventilated under heavy use.", systemImage: "info.circle")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .padding(.top, 4)
+        }
+    }
+
+    private var helperStep: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            header(symbol: "key.fill", title: "Skip the password prompts")
+            Text("Install a small background helper so turning keep-awake on and off never asks for your admin password — and the safety watchdog can run.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            helperStatusBox
+
+            Text("Optional — Lidless still works without it; it'll just ask for your password each time you toggle.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    @ViewBuilder
+    private var helperStatusBox: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if state.usingHelper {
+                Label("Background helper installed and active.", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+            } else if state.helperNeedsApproval {
+                Label("Approve Lidless under System Settings ▸ Login Items, then come back here.", systemImage: "exclamationmark.circle.fill")
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                Button("Open Login Items to approve…") { state.installHelper() }
+            } else {
+                Button("Install background helper…") { state.installHelper() }
+                    .buttonStyle(.borderedProminent)
+            }
+
+            if let err = state.lastError, !state.usingHelper {
+                Text(err)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    private var doneStep: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            header(symbol: "checkmark.circle.fill", title: "You're all set")
+            Text("Click the Lidless icon in the menu bar and flip **Keep awake with lid closed** whenever you need it. Safety options live in Settings.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Toggle("Launch Lidless at login", isOn: Binding(
+                get: { state.launchAtLogin },
+                set: { state.setLaunchAtLogin($0) }
+            ))
+            .toggleStyle(.switch)
+            .padding(.top, 8)
+        }
+    }
+
+    // MARK: Footer
+
+    private var footer: some View {
+        HStack {
+            Button("Back") {
+                withAnimation { step -= 1 }
+            }
+            .disabled(step == 0)
+            .opacity(step == 0 ? 0 : 1)
+
+            Spacer()
+
+            HStack(spacing: 6) {
+                ForEach(0...lastStep, id: \.self) { i in
+                    Circle()
+                        .fill(i == step ? Color.accentColor : Color.secondary.opacity(0.3))
+                        .frame(width: 7, height: 7)
+                }
+            }
+
+            Spacer()
+
+            Button(step == lastStep ? "Done" : "Continue") {
+                if step == lastStep {
+                    state.completeOnboarding()
+                } else {
+                    withAnimation { step += 1 }
+                }
+            }
+            .keyboardShortcut(.defaultAction)
+        }
+    }
+
+    // MARK: Helpers
+
+    private func header(symbol: String, title: String) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Image(systemName: symbol)
+                .font(.system(size: 36))
+                .foregroundStyle(.tint)
+            Text(title)
+                .font(.title.weight(.semibold))
+        }
+    }
+
+    private func bullet(_ symbol: String, _ text: String) -> some View {
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: symbol)
+                .font(.title3)
+                .foregroundStyle(.tint)
+                .frame(width: 26)
+            Text(text)
+                .font(.callout)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+    }
+}

--- a/Sources/Lidless/SettingsView.swift
+++ b/Sources/Lidless/SettingsView.swift
@@ -15,6 +15,7 @@ struct SettingsView: View {
                     get: { state.launchAtLogin },
                     set: { state.setLaunchAtLogin($0) }
                 ))
+                Button("Show Setup Guide…") { state.showOnboarding() }
             }
 
             Section {

--- a/Sources/Shared/SettingsStore.swift
+++ b/Sources/Shared/SettingsStore.swift
@@ -11,6 +11,7 @@ public struct SettingsStore {
         static let pauseThermal = "pauseOnHighThermal"
         static let seeded       = "settingsSeeded"
         static let autoOff      = "autoOffMinutes"
+        static let onboarded    = "onboardingComplete"
     }
 
     public init(defaults: UserDefaults = .standard) {
@@ -40,5 +41,14 @@ public struct SettingsStore {
 
     public func saveAutoOffMinutes(_ minutes: Int) {
         defaults.set(minutes, forKey: Key.autoOff)
+    }
+
+    /// Whether the user has been through first-run onboarding. Defaults to false.
+    public func loadOnboardingComplete() -> Bool {
+        defaults.bool(forKey: Key.onboarded)
+    }
+
+    public func saveOnboardingComplete(_ complete: Bool) {
+        defaults.set(complete, forKey: Key.onboarded)
     }
 }

--- a/Tests/LidlessTests/SharedLogicTests.swift
+++ b/Tests/LidlessTests/SharedLogicTests.swift
@@ -116,4 +116,21 @@ final class SharedLogicTests: XCTestCase {
         XCTAssertEqual(AutoOff.optionLabel(minutes: 120), "2 hours")
         XCTAssertEqual(AutoOff.optionLabel(minutes: 240), "4 hours")
     }
+
+    // MARK: SettingsStore onboarding flag
+
+    func testOnboardingDefaultsToIncomplete() {
+        let defaults = UserDefaults(suiteName: "lidless.test.onboarding.default")!
+        defaults.removePersistentDomain(forName: "lidless.test.onboarding.default")
+        let store = SettingsStore(defaults: defaults)
+        XCTAssertFalse(store.loadOnboardingComplete())
+    }
+
+    func testOnboardingCompletePersists() {
+        let defaults = UserDefaults(suiteName: "lidless.test.onboarding.persist")!
+        defaults.removePersistentDomain(forName: "lidless.test.onboarding.persist")
+        let store = SettingsStore(defaults: defaults)
+        store.saveOnboardingComplete(true)
+        XCTAssertTrue(SettingsStore(defaults: defaults).loadOnboardingComplete())
+    }
 }


### PR DESCRIPTION
## Summary
Lidless had no onboarding — a new user saw a menu-bar icon and got an unexplained admin-password prompt on the first toggle. This adds a focused first-run setup window.

Research confirmed Lidless needs **no TCC/privacy permissions** (no camera/mic/disk/accessibility/automation/notifications). The only real system interaction is the **optional** background-helper approval in System Settings ▸ Login Items, plus optional launch-at-login. So onboarding's job is narrow: explain the value and walk through that one step.

## The flow (4 steps)
1. **Welcome** — app icon + what Lidless does.
2. **How it works & safety** — overrides lid-close sleep; auto-pauses on heat/low battery; watchdog restores sleep if the app quits.
3. **Skip the password prompts** — install/approve the background helper, with live status (install → approve → active) and a skippable path (the admin-password fallback still works).
4. **You're all set** — how to use it + an optional Launch-at-login toggle.

- Auto-shown once on first launch (persisted flag), and re-openable anytime via Settings → **Show Setup Guide…**
- Native SwiftUI, no custom art. Hosted in an AppKit `NSWindow` for reliable presentation from this `LSUIElement` app.

## Implementation
- New `OnboardingView.swift` (step flow) + `OnboardingController.swift` (window host).
- `AppState`: `onboardingComplete` flag, `showOnboarding()` / `completeOnboarding()`, first-run auto-present.
- `SettingsStore`: persist the flag (+ 2 unit tests).
- Reuses existing `installHelper()`, helper-status properties, and `setLaunchAtLogin()` — **no new permission logic**.

## Verification
- `xcodebuild test -scheme Lidless-CI` → **27 tests pass** (25 + 2 new).
- Release build succeeds.
- Manually verified: resetting the flag and launching auto-presents the window at the Welcome step; the flag persists so it shows only once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)