### PR TITLE
Remove "Check for Updates…" from the menu bar popover

### DIFF
--- a/Sources/Lidless/LidlessApp.swift
+++ b/Sources/Lidless/LidlessApp.swift
@@ -9,7 +9,6 @@ struct LidlessApp: App {
         MenuBarExtra {
             MenuContent()
                 .environmentObject(state)
-                .environmentObject(updater)
         } label: {
             Image(state.isEnabled ? "MenubarLaptopActive" : "MenubarLaptop")
         }

--- a/Sources/Lidless/MenuContent.swift
+++ b/Sources/Lidless/MenuContent.swift
@@ -224,18 +224,9 @@ private struct SafetySection: View {
 // MARK: - Footer
 
 private struct FooterActions: View {
-    @EnvironmentObject private var updater: UpdaterController
-
     var body: some View {
         HStack {
             SettingsButton()
-            Button {
-                updater.checkForUpdates()
-            } label: {
-                Label("Check for Updates…", systemImage: "arrow.down.circle")
-                    .foregroundStyle(.secondary)
-            }
-            .disabled(!updater.canCheckForUpdates)
             Spacer()
             Button {
                 NSApplication.shared.terminate(nil)


### PR DESCRIPTION
## Summary
The "Check for Updates…" action already lives in **Settings → Updates**, so the duplicate button in the menu bar popover footer was redundant. This removes it.

## Changes
- Drop the "Check for Updates…" button from `FooterActions` in `MenuContent.swift`.
- Remove the now-unused `UpdaterController` injection into `MenuContent` (the `MenuBarExtra` scene in `LidlessApp.swift`); the `Settings` scene still receives it.

The footer is now just **Settings… | Quit Lidless**. The auto-check toggle + manual "Check for Updates…" button in Settings are unchanged.

## Verification
- `xcodegen generate && xcodebuild build -scheme Lidless` — **BUILD SUCCEEDED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)