### PR TITLE
Point Sparkle feed at raw.githubusercontent

### DIFF
--- a/Sources/Lidless/Info.plist
+++ b/Sources/Lidless/Info.plist
@@ -29,7 +29,7 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2026 Nghia Luong</string>
 	<key>SUFeedURL</key>
-	<string>https://nghialuong.github.io/Lidless/appcast.xml</string>
+	<string>https://raw.githubusercontent.com/nghialuong/Lidless/main/docs/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>pmOUhSI4qLDIbgndphAMYGc/oZJIk9Nw9KdEcmJBSOY=</string>
 	<key>SUEnableAutomaticChecks</key>

--- a/project.yml
+++ b/project.yml
@@ -35,7 +35,7 @@ targets:
         CFBundleIconName: AppIcon
         LSMinimumSystemVersion: "13.0"
         NSHumanReadableCopyright: "© 2026 Nghia Luong"
-        SUFeedURL: https://nghialuong.github.io/Lidless/appcast.xml
+        SUFeedURL: https://raw.githubusercontent.com/nghialuong/Lidless/main/docs/appcast.xml
         SUPublicEDKey: pmOUhSI4qLDIbgndphAMYGc/oZJIk9Nw9KdEcmJBSOY=
         SUEnableAutomaticChecks: true
         SUScheduledCheckInterval: 86400


### PR DESCRIPTION
GitHub Pages can't host the appcast for this repo: the account's Pages custom domain `nghialuong.com` is on Vercel, so GitHub 301-redirects the github.io feed URL there → 404. Switch `SUFeedURL` to the raw file on `main` (works now that the repo is public).

- Old: `https://nghialuong.github.io/Lidless/appcast.xml` (redirects to Vercel, 404)
- New: `https://raw.githubusercontent.com/nghialuong/Lidless/main/docs/appcast.xml`

`release.sh` is unchanged (still commits `docs/appcast.xml` to main + uploads the DMG asset). Requires a re-release so the app picks up the new feed URL.

Verified locally: `xcodegen generate` + `Lidless-CI` → 27 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)