### PR TITLE
Keep Sparkle feed to a single current-build entry

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -4,27 +4,11 @@
         <title>Lidless</title>
         <item>
             <title>0.1.0</title>
-            <pubDate>Sat, 20 Jun 2026 15:36:29 +0700</pubDate>
+            <pubDate>Sat, 20 Jun 2026 17:52:24 +0700</pubDate>
             <sparkle:version>36</sparkle:version>
             <sparkle:shortVersionString>0.1.0</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
             <enclosure url="https://github.com/nghialuong/Lidless/releases/latest/download/Lidless-0.1.0.dmg" length="3562407" type="application/octet-stream" sparkle:edSignature="snVraMVvZGyVGC1NZ0QT4o9lpTEkMychWRDgzEp5KQwBECMjNpG2fjLdFo0JxVQVPVuAeUB4D66rOnWaf5puCA=="/>
-        </item>
-        <item>
-            <title>0.1.0</title>
-            <pubDate>Sat, 20 Jun 2026 15:36:29 +0700</pubDate>
-            <sparkle:version>33</sparkle:version>
-            <sparkle:shortVersionString>0.1.0</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/nghialuong/Lidless/releases/latest/download/Lidless-0.1.0.dmg" length="3561931" type="application/octet-stream" sparkle:edSignature="SrQQkmojzLaQ/N04r0t1fVyvPK+Ypm0PwF2CMT9Od05P3yZ/NbUnRDr5PRGQ7nKWBBq7CsqOpq5lWfqJQGRgBg=="/>
-        </item>
-        <item>
-            <title>0.1.0</title>
-            <pubDate>Sat, 20 Jun 2026 15:36:29 +0700</pubDate>
-            <sparkle:version>24</sparkle:version>
-            <sparkle:shortVersionString>0.1.0</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/nghialuong/Lidless/releases/latest/download/Lidless-0.1.0.dmg" length="3550814" type="application/octet-stream" sparkle:edSignature="JBWr11hokrD7c+SzBoaSlQWtDkmPVwH14bFoqz2GYbzZDs4zVJjbihk9hKjfUrd4d7d9jvUZDoWe+34wzJTFDg=="/>
         </item>
     </channel>
 </rss>

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -113,12 +113,16 @@ hdiutil create -volname "$APP_NAME" -srcfolder "$STAGING" -ov -format UDZO "$DMG
 
 echo "→ [7/7] sign + generate Sparkle appcast"
 GENERATE_APPCAST=$(sparkle_tool generate_appcast)
+# Start from a clean workspace each release. Every build of the same marketing
+# version ships to one stable "latest" DMG URL, so the feed must advertise only
+# the current build — keeping old entries would point several versions at the
+# same URL with mismatched signatures. Monotonicity is still guarded against the
+# committed docs/appcast.xml above, not this ephemeral dir.
+rm -rf "$UPDATES_DIR"
 mkdir -p "$UPDATES_DIR"
 cp "$DMG" "$UPDATES_DIR/"
-# Sign every archive in UPDATES_DIR with the keychain private key and (re)write
-# the appcast. --download-url-prefix points enclosures at the GitHub Release asset.
-# Note: only archives still present in UPDATES_DIR are kept in the feed; on a
-# fresh checkout this yields a latest-only feed, which Sparkle handles fine.
+# Sign the archive with the keychain private key and write a fresh appcast.
+# --download-url-prefix points the enclosure at the GitHub Release asset.
 "$GENERATE_APPCAST" --download-url-prefix "$DOWNLOAD_URL_PREFIX/" "$UPDATES_DIR"
 mkdir -p "$(dirname "$PAGES_APPCAST")"
 cp "$APPCAST" "$PAGES_APPCAST"


### PR DESCRIPTION
`generate_appcast` merged entries from prior runs (the gitignored `updates/` workspace persists locally), so the feed accumulated builds 24/33/36 all pointing at the same `latest/download/Lidless-0.1.0.dmg` URL with different signatures. Sparkle still picked the newest, but the feed was incorrect.

- `release.sh` now wipes `updates/` before `generate_appcast` → fresh single-entry feed per release. Monotonicity still guarded against committed `docs/appcast.xml`.
- Regenerated the live `docs/appcast.xml` to just build 36.

Verified: single `<item>` (build 36, signature matches the published DMG); 27 tests pass; `bash -n` clean.