### PR TITLE
Fix keep-awake helper never launching; surface toggle failures

### DIFF
--- a/Sources/Lidless/AppState.swift
+++ b/Sources/Lidless/AppState.swift
@@ -252,12 +252,16 @@ final class AppState: ObservableObject {
         }
     }
 
-    func toggle() { setEnabled(!isEnabled) }
+    /// User flipped the toggle: treat it as user-initiated so any failure or
+    /// refusal surfaces a visible alert (not just the easy-to-miss inline note).
+    func toggle() { setEnabled(!isEnabled, userInitiated: true) }
 
     /// Set keep-awake. `note` is shown to the user on a successful change
     /// (used when an auto-pause or the auto-off timer disables it); nil clears
-    /// any prior message.
-    func setEnabled(_ target: Bool, note: String? = nil) {
+    /// any prior message. When `userInitiated` is true (the user flipped the
+    /// toggle), a failure or policy refusal also pops a blocking alert so it
+    /// can't go unnoticed; background callers leave it false to stay quiet.
+    func setEnabled(_ target: Bool, note: String? = nil, userInitiated: Bool = false) {
         // Refuse to enable if it would immediately violate the safety policy.
         if target {
             let info = battery.read()
@@ -265,6 +269,9 @@ final class AppState: ObservableObject {
                                                              thermalSerious: thermalSerious(),
                                                              settings: settings) {
                 lastError = blocker.message
+                if userInitiated {
+                    presentFailureAlert(target: target, message: blocker.blockedMessage)
+                }
                 return
             }
         }
@@ -278,7 +285,11 @@ final class AppState: ObservableObject {
                     self.manageHeartbeat()
                     self.updateAutoOff(for: target)
                 } else {
-                    self.lastError = err
+                    // The helper can fail without a message (e.g. a dropped XPC
+                    // reply); don't let that turn into a silent no-op.
+                    let message = err ?? "The background helper didn't respond. Try again, or reinstall it from Settings."
+                    self.lastError = message
+                    if userInitiated { self.presentFailureAlert(target: target, message: message) }
                     self.refreshState()
                 }
             }
@@ -290,9 +301,23 @@ final class AppState: ObservableObject {
                 updateAutoOff(for: target)
             } catch {
                 lastError = error.localizedDescription
+                if userInitiated { presentFailureAlert(target: target, message: error.localizedDescription) }
                 isEnabled = fallback.isSleepDisabled()
             }
         }
+    }
+
+    /// Pop a blocking alert when a user-initiated toggle can't be applied, so the
+    /// reason is impossible to miss. The inline `lastError` note still persists in
+    /// the popover after the alert is dismissed.
+    private func presentFailureAlert(target: Bool, message: String) {
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = target ? "Couldn't keep your Mac awake" : "Couldn't turn keep-awake off"
+        alert.informativeText = message
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
     }
 
     // MARK: Heartbeat (keeps the helper watchdog satisfied)

--- a/Sources/Lidless/AppState.swift
+++ b/Sources/Lidless/AppState.swift
@@ -62,6 +62,7 @@ final class AppState: ObservableObject {
         onboardingComplete = store.loadOnboardingComplete()
         launchAtLogin = loginItem.isEnabled
         refreshHelperStatus()
+        refreshHelperRegistrationIfUpdated()
         helperWasUsable = usingHelper
         refreshState()
         refreshBattery()
@@ -161,6 +162,32 @@ final class AppState: ObservableObject {
         helperInstalled = helper.isEnabled
         helperNeedsApproval = helper.requiresApproval
         usingHelper = helperInstalled
+    }
+
+    /// The app's current build number (`CFBundleVersion`).
+    private var currentBuild: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? ""
+    }
+
+    private func storeCurrentHelperBuild() {
+        store.saveLastHelperBuild(currentBuild)
+    }
+
+    /// After an app update the helper binary is re-signed and its launchd job can
+    /// keep a stale launch record, so the daemon fails to start (EX_CONFIG) and
+    /// XPC calls hang — the toggle then silently does nothing. On the first launch
+    /// of a new build, probe the registered daemon; only if it's unreachable do we
+    /// rebuild its registration (which may require re-approval). Healthy updates
+    /// are left untouched, so they don't needlessly prompt for approval.
+    private func refreshHelperRegistrationIfUpdated() {
+        guard !currentBuild.isEmpty else { return }
+        guard store.loadLastHelperBuild() != currentBuild else { return }
+        storeCurrentHelperBuild()
+        guard helper.isEnabled else { return }
+        helper.checkReachable { [weak self] reachable in
+            guard let self, !reachable else { return }
+            self.repairHelper()
+        }
     }
 
     /// Re-read helper status; if it just became usable (the user approved it while
@@ -286,10 +313,11 @@ final class AppState: ObservableObject {
                     self.updateAutoOff(for: target)
                 } else {
                     // The helper can fail without a message (e.g. a dropped XPC
-                    // reply); don't let that turn into a silent no-op.
-                    let message = err ?? "The background helper didn't respond. Try again, or reinstall it from Settings."
+                    // reply, or the daemon failing to launch after an update);
+                    // surface it instead of letting the toggle silently no-op.
+                    let message = err ?? "The background helper didn’t respond."
                     self.lastError = message
-                    if userInitiated { self.presentFailureAlert(target: target, message: message) }
+                    if userInitiated { self.presentHelperFailureAlert(message: message) }
                     self.refreshState()
                 }
             }
@@ -314,10 +342,46 @@ final class AppState: ObservableObject {
         NSApp.activate(ignoringOtherApps: true)
         let alert = NSAlert()
         alert.alertStyle = .warning
-        alert.messageText = target ? "Couldn't keep your Mac awake" : "Couldn't turn keep-awake off"
+        alert.messageText = target ? "Couldn’t keep your Mac awake" : "Couldn’t turn keep-awake off"
         alert.informativeText = message
         alert.addButton(withTitle: "OK")
         alert.runModal()
+    }
+
+    /// The helper is registered but didn't respond — almost always a stale
+    /// registration after an app update (launchd refuses to launch the new
+    /// binary). Offer a one-click reinstall, which re-registers and refreshes
+    /// that record.
+    private func presentHelperFailureAlert(message: String) {
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Couldn’t keep your Mac awake"
+        alert.informativeText = "\(message)\n\nThis usually happens after an update. Reinstalling the background helper fixes it."
+        alert.addButton(withTitle: "Reinstall Helper…")
+        alert.addButton(withTitle: "Cancel")
+        if alert.runModal() == .alertFirstButtonReturn {
+            repairHelper()
+        }
+    }
+
+    /// Re-register the privileged helper to refresh launchd's record, then report
+    /// the outcome. Used both automatically (after a detected app update) and from
+    /// the failure alert's "Reinstall Helper" action.
+    func repairHelper() {
+        helper.reregister { [weak self] error in
+            guard let self else { return }
+            self.refreshHelperStatus()
+            self.storeCurrentHelperBuild()
+            if let error {
+                self.lastError = error.localizedDescription
+            } else if self.helper.requiresApproval {
+                self.lastError = "Approve Lidless in System Settings ▸ Login Items, then try the switch again."
+                self.helper.openLoginItemsSettings()
+            } else {
+                self.lastError = "Background helper reinstalled — try the switch again."
+            }
+        }
     }
 
     // MARK: Heartbeat (keeps the helper watchdog satisfied)

--- a/Sources/Lidless/HelperManager.swift
+++ b/Sources/Lidless/HelperManager.swift
@@ -31,6 +31,31 @@ final class HelperManager {
 
     func unregister() throws { try service.unregister() }
 
+    /// Rebuild the registration from scratch so launchd picks up the *current*
+    /// binary. After an app update the daemon's code signature changes and its
+    /// launchd job keeps a stale bundle/requirement reference, so launchd refuses
+    /// to start the new binary (EX_CONFIG / "could not find and/or execute
+    /// program"). A plain re-`register()` does *not* clear that — only a full
+    /// unregister (which boots the old job) followed by a fresh register does.
+    ///
+    /// `unregister` is asynchronous, so we register from its completion (a
+    /// register issued immediately after fails with the unregister still settling).
+    /// `completion` is delivered on the main queue with any registration error.
+    func reregister(completion: @escaping (Error?) -> Void) {
+        let svc = service
+        svc.unregister { _ in
+            // Give launchd/BTM a moment to drop the old job before re-adding it.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                do {
+                    try svc.register()
+                    completion(nil)
+                } catch {
+                    completion(error)
+                }
+            }
+        }
+    }
+
     func openLoginItemsSettings() {
         SMAppService.openSystemSettingsLoginItems()
         // Fallback: the SMAppService call silently no-ops for LSUIElement apps
@@ -62,26 +87,52 @@ final class HelperManager {
     }
 
     func setKeepAwake(_ enabled: Bool, completion: @escaping (Bool, String?) -> Void) {
-        guard let r = remote({ completion(false, $0) }) else {
-            completion(false, "No helper connection")
-            return
-        }
-        r.setKeepAwake(enabled) { ok, err in
-            DispatchQueue.main.async { completion(ok, err) }
+        callWithTimeout(completion: completion) { proxy, done in
+            proxy.setKeepAwake(enabled) { ok, err in done(ok, err) }
         }
     }
 
     func getState(completion: @escaping (Bool) -> Void) {
-        guard let r = remote({ _ in completion(false) }) else {
-            completion(false)
-            return
-        }
-        r.getState { value in
-            DispatchQueue.main.async { completion(value) }
+        callWithTimeout(completion: { ok, _ in completion(ok) }) { proxy, done in
+            proxy.getState { value in done(value, nil) }
         }
     }
 
     func heartbeat() {
         remote({ _ in })?.heartbeat { _ in }
+    }
+
+    /// True if the daemon answers an XPC call, false if it can't be reached
+    /// (connection error or no reply within the timeout). Used to detect a
+    /// registered-but-unlaunchable helper after an app update.
+    func checkReachable(completion: @escaping (Bool) -> Void) {
+        callWithTimeout(timeout: 5, completion: { ok, _ in completion(ok) }) { proxy, done in
+            proxy.version { _ in done(true, nil) }
+        }
+    }
+
+    /// Run a single XPC call, guaranteeing `completion` fires exactly once on the
+    /// main queue. If the daemon never replies — e.g. it fails to launch after an
+    /// update, so neither the reply nor the connection's error handler ever fires
+    /// — a timeout reports failure instead of leaving the UI hung and silent.
+    private func callWithTimeout(timeout: TimeInterval = 6,
+                                 completion: @escaping (Bool, String?) -> Void,
+                                 _ body: (LidlessHelperProtocol, @escaping (Bool, String?) -> Void) -> Void) {
+        var finished = false
+        let finish: (Bool, String?) -> Void = { ok, err in
+            DispatchQueue.main.async {
+                guard !finished else { return }
+                finished = true
+                completion(ok, err)
+            }
+        }
+        guard let proxy = remote({ finish(false, $0) }) else {
+            finish(false, "No helper connection")
+            return
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + timeout) {
+            finish(false, "The background helper isn’t responding.")
+        }
+        body(proxy) { ok, err in finish(ok, err) }
     }
 }

--- a/Sources/Shared/SafetySettings.swift
+++ b/Sources/Shared/SafetySettings.swift
@@ -32,6 +32,16 @@ public enum SafetyReason: Equatable {
         case .lowBattery(let p):  return "Auto-paused: battery \(p)% on battery power."
         }
     }
+
+    /// Phrasing for when the user *tries to turn keep-awake on* but the policy
+    /// won't allow it (vs. `message`, which describes a background auto-pause).
+    public var blockedMessage: String {
+        switch self {
+        case .highThermal:        return "Your Mac is running hot, so keep-awake is paused. It'll be available again once the Mac cools down."
+        case .notCharging:        return "\u{201C}Only while charging\u{201D} is on, so connect your Mac to power to keep it awake."
+        case .lowBattery(let p):  return "Battery is at \(p)%. Charge above the low-battery cutoff to keep your Mac awake."
+        }
+    }
 }
 
 /// Pure safety decision. No side effects, fully unit-testable.

--- a/Sources/Shared/SettingsStore.swift
+++ b/Sources/Shared/SettingsStore.swift
@@ -13,6 +13,7 @@ public struct SettingsStore {
         static let autoOff      = "autoOffMinutes"
         static let onboarded    = "onboardingComplete"
         static let resumeOnboarding = "resumeOnboarding"
+        static let helperBuild  = "lastRegisteredHelperBuild"
     }
 
     public init(defaults: UserDefaults = .standard) {
@@ -62,5 +63,17 @@ public struct SettingsStore {
 
     public func saveResumeOnboarding(_ resume: Bool) {
         defaults.set(resume, forKey: Key.resumeOnboarding)
+    }
+
+    /// The app build (`CFBundleVersion`) for which the privileged helper was last
+    /// (re-)registered. Used to refresh the launchd registration after an update,
+    /// so the daemon keeps launching with the new binary's requirement. Empty
+    /// until the first registration.
+    public func loadLastHelperBuild() -> String {
+        defaults.string(forKey: Key.helperBuild) ?? ""
+    }
+
+    public func saveLastHelperBuild(_ build: String) {
+        defaults.set(build, forKey: Key.helperBuild)
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -100,6 +100,13 @@ targets:
         # products so Xcode writes no ApplicationProperties — which makes
         # `xcodebuild -exportArchive` reject every distribution method.
         SKIP_INSTALL: YES
+        # Embed an Info.plist (with CFBundleIdentifier) into the tool binary.
+        # SMAppService daemons need this code identity to form the launch
+        # constraint (LWCR) that ties the daemon to the app; without it macOS
+        # refuses to exec the daemon ("could not find and/or execute program"
+        # / copy_bundle_path error) and the helper never launches.
+        GENERATE_INFOPLIST_FILE: YES
+        CREATE_INFOPLIST_SECTION_IN_BINARY: YES
       configs:
         # Helper bundle id tracks the app's (`<app id>.helper`) per build config.
         Debug:


### PR DESCRIPTION
## Problem

Toggling **Keep awake with lid closed** did nothing — the switch wouldn't move and **no error was shown**. Investigation found the privileged helper daemon had *never* successfully launched on the test machine; toggling silently fell back to a per-use admin-password prompt (or hung with no feedback at all).

## Root cause

The helper is a command-line `tool` target embedded in the app and registered as an `SMAppService` LaunchDaemon. It shipped **with no embedded `Info.plist`**, so its code signature carried no `CFBundleIdentifier`. On macOS the daemon's launch constraint (LWCR) is keyed off that code identity — without it the kernel refuses to `exec` the daemon:

```
launchd: Could not find and/or execute program specified by service: 3: No such process: Contents/MacOS/LidlessHelper
launchd: Service could not initialize: copy_bundle_path(...), error 0x6f - Invalid or missing Program/ProgramArguments  (EX_CONFIG)
```

Because the XPC call to the never-launching daemon got neither a reply nor an error, the toggle silently no-op'd.

(Confirmed against the reference app *Macchiato*, which uses the same SMAppService + `pmset disablesleep` design but ships the helper **with** an embedded Info.plist / bundle-id code identity.)

## Fix

- **`Embed Info.plist in the helper tool`** — `GENERATE_INFOPLIST_FILE` + `CREATE_INFOPLIST_SECTION_IN_BINARY` give the helper a real code identity (`codesign` now reports `Identifier=com.nghialuong.lidless.helper`). The daemon now launches: `launchd: Successfully spawned LidlessHelper`. **This is the core fix.**
- **`Recover the helper after an app update; never fail the toggle silently`** — XPC calls (`setKeepAwake`/`getState`) now run through a timeout so the completion always fires instead of hanging forever; on a new build the app probes the registered daemon and rebuilds its registration (full unregister → register) if it's unreachable; failures offer a one-click **Reinstall Helper**.
- **`Surface keep-awake toggle failures with an alert`** — a user-initiated toggle that fails or is blocked by the safety policy now shows a clear alert instead of only an easy-to-miss inline note.

## Verification

- `xcodebuild test -scheme Lidless-CI` → **TEST SUCCEEDED** (27 tests)
- `xcodebuild build -scheme Lidless` (Debug) → **BUILD SUCCEEDED**
- Notarized build installed; after clearing the dev machine's wedged BackgroundTaskManagement state, the helper daemon launches (`state = running`, real PID, `last exit = never exited`), the toggle works without a password, and `pmset disablesleep` flips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)