### PR TITLE
Release 0.1.1

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -30,7 +30,7 @@ targets:
         LSUIElement: true
         CFBundleName: Lidless
         CFBundleDisplayName: Lidless
-        CFBundleShortVersionString: "0.1.0"
+        CFBundleShortVersionString: "0.1.1"
         CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         CFBundleIconName: AppIcon
         LSMinimumSystemVersion: "13.0"
@@ -41,7 +41,7 @@ targets:
         SUScheduledCheckInterval: 86400
     settings:
       base:
-        MARKETING_VERSION: "0.1.0"
+        MARKETING_VERSION: "0.1.1"
         CURRENT_PROJECT_VERSION: "1"
         ENABLE_HARDENED_RUNTIME: YES
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon


### PR DESCRIPTION
Bumps `CFBundleShortVersionString` / `MARKETING_VERSION` to **0.1.1**.

This is the release carrying the keep-awake helper fix from #17:
- Helper tool now embeds an Info.plist (code identity) so the SMAppService daemon actually launches on macOS (was failing with `EX_CONFIG` / `copy_bundle_path`).
- XPC calls time out instead of hanging; the app self-repairs a stale helper registration after an update.
- Toggle failures now surface a clear alert with a one-click **Reinstall Helper**.

### Verification
- `xcodebuild test -scheme Lidless-CI` → **TEST SUCCEEDED** (27 tests)
- `xcodebuild build -scheme Lidless` (Debug) → **BUILD SUCCEEDED**
- Generated Info.plist reports `CFBundleShortVersionString = 0.1.1`.

After merge: run `scripts/release.sh` from `main` to notarize, tag `v0.1.1`, publish the DMG, and update the Sparkle appcast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)