### PR TITLE
docs: add total downloads badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Lidless
 
+[![Downloads](https://img.shields.io/github/downloads/nghialuong/Lidless/total)](https://github.com/nghialuong/Lidless/releases)
+
 A tiny macOS menu-bar app that keeps your Mac running **even with the lid closed** —
 so coding agents (Claude Code, Codex, etc.) keep working while you move around.
 


### PR DESCRIPTION
Adds a shields.io badge showing total downloads across all GitHub releases (currently ~102), linking to the releases page. Auto-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)