### PR TITLE
Reconcile the keep-awake toggle with the real SleepDisabled flag

### DIFF
--- a/Sources/Lidless/AppState.swift
+++ b/Sources/Lidless/AppState.swift
@@ -14,6 +14,14 @@ final class AppState: ObservableObject {
     @Published var batteryOnAC = false
     @Published var lastError: String?
 
+    /// Explains a toggle that moved by itself. Its own channel, so an external
+    /// change and a safety pause can both be on screen at once.
+    @Published var externalNotice: String?
+
+    /// Transient status of a write we haven't been able to confirm. Also its own
+    /// channel, so clearing it can't disturb `lastError`.
+    @Published var verificationNotice: String?
+
     /// True when using the privileged helper; false when on the M1 admin-prompt fallback.
     @Published var usingHelper = false
 
@@ -35,7 +43,9 @@ final class AppState: ObservableObject {
     @Published var onboardingComplete = false
 
     private let helper = HelperManager()
-    private let fallback = PowerManager()
+    /// Reads the flag on every path — `pmset -g` needs no privileges — and also
+    /// writes it when the helper isn't installed.
+    private let power = PowerManager()
     private let battery = BatteryMonitor()
     private let store = SettingsStore()
     private let loginItem = LoginItemManager()
@@ -67,6 +77,14 @@ final class AppState: ObservableObject {
     /// Last-known "helper is usable" value, so we can detect it flipping on at
     /// runtime (right after the user approves it) and prompt a restart.
     private var helperWasUsable = false
+    /// True once the system flag has been read successfully this session. Set
+    /// only by a read — a write's success reply is a claim, not a reading, and
+    /// treating it as one would let an unconfirmed write masquerade as drift.
+    private var hasConfirmedState = false
+    /// The write currently awaiting confirmation, if any.
+    private var pendingVerification: PendingVerification?
+    /// Rejects async replies that have been superseded.
+    private var sync = StateSync()
     /// True while the onboarding window is open and not yet completed.
     private var onboardingActive = false
     private var didBecomeActiveObserver: NSObjectProtocol?
@@ -90,7 +108,13 @@ final class AppState: ObservableObject {
         didBecomeActiveObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.didBecomeActiveNotification, object: nil, queue: .main
         ) { [weak self] _ in
-            Task { @MainActor in self?.recheckHelper() }
+            Task { @MainActor in
+                self?.recheckHelper()
+                // Also re-read the flag: it may have been changed from a Terminal
+                // the user was just in. `recheckHelper` only refreshes on the rare
+                // helper unusable→usable transition.
+                self?.refreshState()
+            }
         }
         // First launch shows onboarding once (persisted so closing it early won't
         // re-nag). A relaunch triggered mid-onboarding resumes the flow instead.
@@ -172,7 +196,7 @@ final class AppState: ObservableObject {
                                                         settings: settings) {
             // Pass the message through so it survives the async helper callback
             // (which would otherwise clear lastError on success).
-            setEnabled(false, note: reason.message)
+            setEnabled(false, note: reason.message, origin: .safety)
         }
     }
 
@@ -291,67 +315,183 @@ final class AppState: ObservableObject {
 
     // MARK: State
 
+    /// Read the real `SleepDisabled` flag and bring the UI into step with it.
+    ///
+    /// Always read directly rather than asking the helper: the XPC reply is a
+    /// plain `Bool`, so a `pmset` failure inside the daemon would arrive as a
+    /// confident "off". Reading needs no privileges, so there's nothing to gain
+    /// by routing it through root — and an unknown stays an unknown.
     func refreshState() {
-        if helperInstalled {
-            helper.getState { [weak self] value in self?.isEnabled = value }
-        } else {
-            isEnabled = fallback.isSleepDisabled()
+        let token = sync.beginRead()
+        applyObserved(power.isSleepDisabled(), token)
+    }
+
+    private func applyObserved(_ observed: Bool?, _ token: StateSync.ReadToken) {
+        guard sync.shouldApply(token) else { return }   // superseded by a newer read or a write
+
+        // A write we haven't confirmed owns the interpretation until it resolves:
+        // a disagreement here is our own write failing to hold, not somebody
+        // else's doing, and mustn't be reported as an external change.
+        if let pending = pendingVerification {
+            switch StateReconciler.resolve(pending, observed: observed) {
+            case .stillUnverified:
+                break
+            case .confirmed:
+                pendingVerification = nil
+                verificationNotice = nil
+                hasConfirmedState = true
+            case .writeMismatch(let actual):
+                pendingVerification = nil
+                verificationNotice = StateReconciler.writeMismatchMessage(actual: actual)
+                hasConfirmedState = true
+                adoptSystemState(actual)
+            }
+            return
+        }
+
+        switch StateReconciler.reconcile(shown: isEnabled,
+                                         hasBaseline: hasConfirmedState,
+                                         observed: observed) {
+        case .unknown:
+            break                                       // keep the last-known state
+        case .inSync:
+            hasConfirmedState = true                    // no side effects, by construction
+        case .adopt(let enabled):
+            hasConfirmedState = true
+            adoptSystemState(enabled)
+        case .drift(let change):
+            hasConfirmedState = true
+            // Set before adopting: adopting `true` can synchronously trip a safety
+            // pause, and the notice should already be in place when it does.
+            externalNotice = change.message
+            adoptSystemState(change.nowEnabled)
         }
     }
 
-    /// User flipped the toggle: treat it as user-initiated so any failure or
-    /// refusal surfaces a visible alert (not just the easy-to-miss inline note).
-    func toggle() { setEnabled(!isEnabled, userInitiated: true) }
+    /// Bring `isEnabled` in line with reality *without* touching the flag, running
+    /// the side effects `setEnabled` would have run for this state.
+    ///
+    /// Only ever reached for a real transition — `reconcile` returns `.inSync`
+    /// when the values already agree — so the 30-second poll can't re-arm the
+    /// auto-off timer or restart the heartbeat on every pass.
+    private func adoptSystemState(_ enabled: Bool) {
+        isEnabled = enabled
+        sync.beginMutation()            // supersede every read and write still in flight
+        manageHeartbeat()
+        updateAutoOff(for: enabled)
+        if enabled { evaluateSafety() }
+    }
+
+    /// User flipped the toggle: `.user` origin so any failure or refusal surfaces
+    /// a visible alert (not just the easy-to-miss inline note).
+    func toggle() { setEnabled(!isEnabled, origin: .user) }
 
     /// Set keep-awake. `note` is shown to the user on a successful change
     /// (used when an auto-pause or the auto-off timer disables it); nil clears
-    /// any prior message. When `userInitiated` is true (the user flipped the
-    /// toggle), a failure or policy refusal also pops a blocking alert so it
-    /// can't go unnoticed; background callers leave it false to stay quiet.
-    func setEnabled(_ target: Bool, note: String? = nil, userInitiated: Bool = false) {
+    /// any prior message. When `origin` is `.user` (the user flipped the toggle),
+    /// a failure or policy refusal also pops a blocking alert so it can't go
+    /// unnoticed; background callers pass their own origin to stay quiet.
+    func setEnabled(_ target: Bool, note: String? = nil, origin: SetOrigin = .user) {
+        if StateReconciler.clearsExternalNotice(origin) { externalNotice = nil }
+
         // Refuse to enable if it would immediately violate the safety policy.
+        // Returns before claiming a mutation, so nothing in flight is disturbed.
         if target {
             let info = battery.read()
             if let blocker = SafetyEvaluator.reasonToDisable(battery: info,
                                                              thermalSerious: thermalSerious(),
                                                              settings: settings) {
                 lastError = blocker.message
-                if userInitiated {
+                if origin == .user {
                     presentFailureAlert(target: target, message: blocker.blockedMessage)
                 }
                 return
             }
         }
         let resultMessage = note
+
+        // A new write supersedes any older one, along with its pending verification.
+        pendingVerification = nil
+        verificationNotice = nil
+        let token = sync.beginMutation()
+
         if helperInstalled {
             helper.setKeepAwake(target) { [weak self] ok, err in
-                guard let self else { return }
+                guard let self, self.sync.shouldApply(token) else { return }   // superseded write
                 if ok {
                     self.isEnabled = target
                     self.lastError = resultMessage
                     self.manageHeartbeat()
                     self.updateAutoOff(for: target)
+                    // Deliberately not `hasConfirmedState`: the helper's success
+                    // reply is a claim about the flag, not a reading of it.
+                    self.pendingVerification = PendingVerification(target: target)
+                    self.verifySetApplied(target: target)
                 } else {
                     // The helper can fail without a message (e.g. a dropped XPC
                     // reply, or the daemon failing to launch after an update);
                     // surface it instead of letting the toggle silently no-op.
                     let message = err ?? "The background helper didn’t respond."
                     self.lastError = message
-                    if userInitiated { self.presentHelperFailureAlert(message: message) }
-                    self.refreshState()
+                    if origin == .user { self.presentHelperFailureAlert(message: message) }
+                    self.recoverStateAfterFailedWrite()
                 }
             }
         } else {
             do {
-                try fallback.setSleepDisabled(target)
+                try power.setSleepDisabled(target)
                 isEnabled = target
                 lastError = resultMessage
                 updateAutoOff(for: target)
+                pendingVerification = PendingVerification(target: target)
+                verifySetApplied(target: target)
             } catch {
                 lastError = error.localizedDescription
-                if userInitiated { presentFailureAlert(target: target, message: error.localizedDescription) }
-                isEnabled = fallback.isSleepDisabled()
+                if origin == .user { presentFailureAlert(target: target, message: error.localizedDescription) }
+                recoverStateAfterFailedWrite()
             }
+        }
+    }
+
+    /// After a write that reported failure we know nothing reliable about the
+    /// flag — the write may still have landed. Go re-read it through the normal
+    /// reconcile path rather than assigning `isEnabled` directly, so the token,
+    /// baseline, and side effects all stay consistent.
+    ///
+    /// The baseline is dropped first so that read re-establishes it silently: if
+    /// the flag did move, that was our own failed write, and blaming an external
+    /// actor for it would be plainly wrong.
+    private func recoverStateAfterFailedWrite() {
+        hasConfirmedState = false
+        refreshState()
+    }
+
+    /// The write reported success — read the flag back to see whether it landed.
+    private func verifySetApplied(target: Bool) {
+        let token = sync.beginRead()
+        let observed = power.isSleepDisabled()
+        guard sync.shouldApply(token) else { return }
+        applyVerification(StateReconciler.verifyAfterSet(target: target, observed: observed),
+                          target: target)
+    }
+
+    /// Verification never writes to `lastError`: it keeps its own channel so
+    /// clearing a caveat can't wipe a safety note or a helper error.
+    private func applyVerification(_ outcome: StateReconciler.VerifyOutcome, target: Bool) {
+        switch outcome {
+        case .verified:
+            pendingVerification = nil
+            verificationNotice = nil
+            hasConfirmedState = true
+        case .unverified:
+            // Keep `pendingVerification` — the next poll resolves it, and until
+            // then the UI says plainly that the state isn't confirmed.
+            verificationNotice = StateReconciler.unverifiedMessage(target: target)
+        case .mismatch(let actual):
+            pendingVerification = nil
+            verificationNotice = StateReconciler.writeMismatchMessage(actual: actual)
+            hasConfirmedState = true
+            adoptSystemState(actual)
         }
     }
 
@@ -448,7 +588,9 @@ final class AppState: ObservableObject {
         if AutoOff.isExpired(deadline: deadline, now: Date()) {
             let minutes = autoOffMinutes
             cancelAutoOff()
-            setEnabled(false, note: "Auto-off: \(AutoOff.optionLabel(minutes: minutes)) elapsed.")
+            setEnabled(false,
+                       note: "Auto-off: \(AutoOff.optionLabel(minutes: minutes)) elapsed.",
+                       origin: .autoOff)
         } else {
             refreshAutoOffRemaining()
         }
@@ -465,6 +607,10 @@ final class AppState: ObservableObject {
         // Backstop for the didBecomeActive observer: catch a helper approval even
         // if the app never lost/regained active state.
         recheckHelper()
+        // Reconcile with the real flag every tick, not only while enabled:
+        // polling only when we think it's on would structurally miss the case
+        // where it was turned on behind our back.
+        refreshState()
         refreshBattery()
         evaluateSafety()
     }

--- a/Sources/Lidless/HelperManager.swift
+++ b/Sources/Lidless/HelperManager.swift
@@ -92,11 +92,10 @@ final class HelperManager {
         }
     }
 
-    func getState(completion: @escaping (Bool) -> Void) {
-        callWithTimeout(completion: { ok, _ in completion(ok) }) { proxy, done in
-            proxy.getState { value in done(value, nil) }
-        }
-    }
+    // No `getState` wrapper: the helper's reply is a plain `Bool`, so a failed
+    // `pmset -g` inside the daemon would come back as "off" and there'd be no
+    // way to tell. Reading needs no privileges, so `PowerManager` reads the flag
+    // directly and can report "unknown". The helper is only used to change it.
 
     func heartbeat() {
         remote({ _ in })?.heartbeat { _ in }

--- a/Sources/Lidless/MenuContent.swift
+++ b/Sources/Lidless/MenuContent.swift
@@ -39,6 +39,27 @@ struct MenuContent: View {
                 .padding(.horizontal, hInset)
                 .padding(.vertical, 10)
 
+            // Three disjoint slots, strongest first: something changed the flag
+            // behind our back, we couldn't confirm our own change, and the
+            // ordinary error/safety note.
+            if let notice = state.externalNotice {
+                Label(notice, systemImage: "exclamationmark.triangle.fill")
+                    .font(.callout)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, hInset)
+                    .padding(.bottom, 10)
+            }
+
+            if let notice = state.verificationNotice {
+                Label(notice, systemImage: "questionmark.circle.fill")
+                    .font(.callout)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, hInset)
+                    .padding(.bottom, 10)
+            }
+
             if let err = state.lastError {
                 Label(err, systemImage: "info.circle")
                     .font(.callout)
@@ -64,6 +85,9 @@ struct MenuContent: View {
                 .padding(.bottom, 14)
         }
         .frame(width: 360)
+        // The popover is the moment the user actually looks at the toggle, so
+        // it's the moment it most needs to be true.
+        .onAppear { state.refreshState() }
     }
 }
 

--- a/Sources/Lidless/PowerManager.swift
+++ b/Sources/Lidless/PowerManager.swift
@@ -12,9 +12,16 @@ import Foundation
 struct PowerManager {
 
     /// Read the current `SleepDisabled` flag from `pmset -g`.
-    func isSleepDisabled() -> Bool {
-        guard let out = Shell.capture("/usr/bin/pmset", ["-g"]) else { return false }
-        return PowerParsers.isSleepDisabled(pmsetG: out)
+    ///
+    /// Returns nil whenever the flag wasn't actually observed — `pmset` failed to
+    /// launch, exited non-zero, or printed something that doesn't state the flag.
+    /// A failed read must never collapse into "off".
+    ///
+    /// Reading needs no privileges, so this is the app's read path whether or not
+    /// the helper is installed; the helper is only needed to *change* the flag.
+    func isSleepDisabled() -> Bool? {
+        guard let out = Shell.capture("/usr/bin/pmset", ["-g"]) else { return nil }
+        return PowerParsers.sleepDisabled(pmsetG: out)
     }
 
     /// Set or clear the flag. Throws with the underlying error message on failure

--- a/Sources/Lidless/Shell.swift
+++ b/Sources/Lidless/Shell.swift
@@ -1,6 +1,11 @@
 import Foundation
 
-/// Tiny helper to run a command and capture stdout. Returns nil on launch error.
+/// Tiny helper to run a command and capture stdout.
+///
+/// Returns nil if the process couldn't be launched *or* exited non-zero. A
+/// failed command usually writes nothing to stdout, and an empty string parses
+/// as a perfectly plausible "flag is off" — so a caller that can't tell the two
+/// apart will quietly invent state it never read.
 enum Shell {
     static func capture(_ path: String, _ args: [String]) -> String? {
         let proc = Process()
@@ -14,8 +19,10 @@ enum Shell {
         } catch {
             return nil
         }
-        proc.waitUntilExit()
+        // Drain before waiting: a full pipe would deadlock a chatty command.
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        proc.waitUntilExit()
+        guard proc.terminationStatus == 0 else { return nil }
         return String(data: data, encoding: .utf8)
     }
 }

--- a/Sources/Shared/PowerParsers.swift
+++ b/Sources/Shared/PowerParsers.swift
@@ -4,18 +4,33 @@ import Foundation
 /// can be unit-tested without touching real power management.
 public enum PowerParsers {
 
-    /// Parse `pmset -g` output and return whether the `SleepDisabled` flag is set.
-    /// The relevant line looks like: ` SleepDisabled        1`
-    public static func isSleepDisabled(pmsetG output: String) -> Bool {
+    /// Parse `pmset -g` output for the `SleepDisabled` flag. The relevant line
+    /// looks like: ` SleepDisabled        1`
+    ///
+    /// Returns nil when the output doesn't actually state the flag — the key is
+    /// absent, or its value is something other than `0`/`1`. Truncated or
+    /// unexpected output must not read as "off": that's a claim the Mac is free
+    /// to sleep, made from data that says nothing of the sort.
+    public static func sleepDisabled(pmsetG output: String) -> Bool? {
         for raw in output.split(separator: "\n") {
             let line = String(raw).lowercased()
             guard line.contains("sleepdisabled") else { continue }
             let remainder = line
                 .replacingOccurrences(of: "sleepdisabled", with: "")
                 .trimmingCharacters(in: .whitespaces)
-            return remainder == "1"
+            switch remainder {
+            case "1": return true
+            case "0": return false
+            default:  return nil
+            }
         }
-        return false
+        return nil
+    }
+
+    /// Lenient form, kept for callers that have no way to act on "unknown" —
+    /// the helper's XPC reply is a plain `Bool`. Prefer `sleepDisabled(pmsetG:)`.
+    public static func isSleepDisabled(pmsetG output: String) -> Bool {
+        sleepDisabled(pmsetG: output) ?? false
     }
 }
 

--- a/Sources/Shared/StateReconciler.swift
+++ b/Sources/Shared/StateReconciler.swift
@@ -1,0 +1,190 @@
+import Foundation
+
+/// A change to the system `SleepDisabled` flag made outside this app — `pmset`
+/// in Terminal, the helper's watchdog, or another build of Lidless.
+public enum ExternalChange: Equatable {
+    case enabledOutside
+    case disabledOutside
+
+    public var nowEnabled: Bool { self == .enabledOutside }
+
+    /// Describes the *event*, not the resulting state: a safety auto-pause can
+    /// flip the state back while this notice is still on screen.
+    public var message: String {
+        switch self {
+        case .enabledOutside:  return "Sleep prevention was turned on outside Lidless."
+        case .disabledOutside: return "Sleep prevention was turned off outside Lidless."
+        }
+    }
+}
+
+/// Why keep-awake is being set. Alert presentation and notice lifecycle key off
+/// this rather than a bare "was this the user?" flag.
+public enum SetOrigin: Equatable {
+    /// The menu-bar toggle, or a control in Settings.
+    case user
+    /// Battery or thermal policy pausing keep-awake.
+    case safety
+    /// The auto-off timer elapsed.
+    case autoOff
+}
+
+/// A write whose read-back hasn't confirmed it yet.
+public struct PendingVerification: Equatable {
+    public let target: Bool
+    public init(target: Bool) { self.target = target }
+}
+
+/// Pure decision logic for keeping the UI in step with the real system flag.
+///
+/// Everything here is a static function over explicit inputs — no AppKit, no
+/// XPC — so the behaviour that matters can be tested directly, the way
+/// `SafetyEvaluator` and `AutoOff` are.
+public enum StateReconciler {
+
+    // MARK: Reconciling a fresh read
+
+    public enum Outcome: Equatable {
+        /// The read failed. Keep showing the last-known state.
+        case unknown
+        /// The read agrees with the UI. Record a baseline; change nothing else.
+        case inSync
+        /// First confirmed read of the session, and it differs. Adopt silently.
+        case adopt(enabled: Bool)
+        /// The flag moved underneath us. Adopt it and say so.
+        case drift(ExternalChange)
+    }
+
+    /// - Parameters:
+    ///   - shown: what the UI currently displays.
+    ///   - hasBaseline: whether the flag has been read successfully this session.
+    ///   - observed: the fresh reading; `nil` when the read failed.
+    ///
+    /// An agreeing read is `.inSync` whether or not a baseline exists, so
+    /// `.adopt` and `.drift` always imply a real transition. That's what keeps
+    /// the 30-second poll from re-arming timers it already armed.
+    ///
+    /// Without a baseline the first differing read adopts silently: `shown` is
+    /// still just its `false` default, so calling that an external change would
+    /// accuse somebody of something that never happened — a relaunch inside the
+    /// helper watchdog's window, for instance.
+    public static func reconcile(shown: Bool, hasBaseline: Bool, observed: Bool?) -> Outcome {
+        guard let observed else { return .unknown }
+        if observed == shown { return .inSync }
+        guard hasBaseline else { return .adopt(enabled: observed) }
+        return .drift(observed ? .enabledOutside : .disabledOutside)
+    }
+
+    // MARK: Notice lifecycle
+
+    /// The "changed outside Lidless" notice is the user's only explanation for a
+    /// toggle that moved by itself, so only the user acting on it clears it.
+    ///
+    /// This matters most in one specific case: adopting an externally-enabled
+    /// flag can immediately trip a safety pause, and if that pause cleared the
+    /// notice, the explanation would vanish at the exact moment it's needed.
+    public static func clearsExternalNotice(_ origin: SetOrigin) -> Bool {
+        origin == .user
+    }
+
+    // MARK: Verifying a write
+
+    public enum VerifyOutcome: Equatable {
+        case verified
+        /// The read-back failed. Keep the requested state — the write did report
+        /// success — but don't present it as confirmed.
+        case unverified
+        /// The read-back contradicts the write.
+        case mismatch(actual: Bool)
+    }
+
+    public static func verifyAfterSet(target: Bool, observed: Bool?) -> VerifyOutcome {
+        guard let observed else { return .unverified }
+        return observed == target ? .verified : .mismatch(actual: observed)
+    }
+
+    public enum PendingResolution: Equatable {
+        case stillUnverified
+        case confirmed
+        case writeMismatch(actual: Bool)
+    }
+
+    /// A later read arriving while a write is still unconfirmed.
+    ///
+    /// This is deliberately *not* treated as external drift. We never confirmed
+    /// our own write landed, so a disagreement is most honestly read as a write
+    /// that didn't hold. An external actor could also have moved the flag in the
+    /// meantime and the two are indistinguishable from here — but reporting the
+    /// state we can see, without blaming a third party we can't observe, is the
+    /// conservative reading.
+    public static func resolve(_ pending: PendingVerification, observed: Bool?) -> PendingResolution {
+        guard let observed else { return .stillUnverified }
+        return observed == pending.target ? .confirmed : .writeMismatch(actual: observed)
+    }
+
+    /// Wording for a write we couldn't confirm. Both directions get a caveat:
+    /// wrongly claiming keep-awake is on strands a build; wrongly claiming sleep
+    /// is restored sends a running Mac into a bag.
+    public static func unverifiedMessage(target: Bool) -> String {
+        target
+            ? "Couldn’t confirm keep-awake with the system — it may not hold when you close the lid."
+            : "Couldn’t confirm sleep was restored — your Mac may still stay awake."
+    }
+
+    /// Wording for a write that demonstrably didn't hold. Kept distinct from
+    /// `ExternalChange.message`, which attributes the change to someone else.
+    public static func writeMismatchMessage(actual: Bool) -> String {
+        actual
+            ? "The change didn’t hold — the system reports keep-awake is on."
+            : "The change didn’t hold — the system reports keep-awake is off."
+    }
+}
+
+/// Decides which async replies are still worth applying.
+///
+/// A single in-flight flag isn't enough. Two reads can be outstanding at once
+/// (popover open plus the 30-second tick) and reply out of order, and two writes
+/// can do the same. Comparing observed values can't catch either, because a
+/// repeated target looks identical and an on→off→on round trip ends where it
+/// started. Monotonic counters can.
+public struct StateSync: Equatable {
+
+    public struct ReadToken: Equatable {
+        let read: UInt64
+        let mutations: UInt64
+    }
+
+    public struct MutationToken: Equatable {
+        let mutation: UInt64
+    }
+
+    private var reads: UInt64 = 0
+    private var mutations: UInt64 = 0
+
+    public init() {}
+
+    /// Issue a token for a read that's about to go out.
+    public mutating func beginRead() -> ReadToken {
+        reads += 1
+        return ReadToken(read: reads, mutations: mutations)
+    }
+
+    /// Claim the next mutation slot — when a write starts, and when a reconciled
+    /// read adopts a new state. Either supersedes everything already in flight.
+    @discardableResult
+    public mutating func beginMutation() -> MutationToken {
+        mutations += 1
+        return MutationToken(mutation: mutations)
+    }
+
+    /// A read applies only if it's the newest read issued *and* nothing has
+    /// mutated the state since it went out.
+    public func shouldApply(_ token: ReadToken) -> Bool {
+        token.read == reads && token.mutations == mutations
+    }
+
+    /// A write completion applies only if it's still the newest mutation.
+    public func shouldApply(_ token: MutationToken) -> Bool {
+        token.mutation == mutations
+    }
+}

--- a/Tests/LidlessTests/SharedLogicTests.swift
+++ b/Tests/LidlessTests/SharedLogicTests.swift
@@ -26,6 +26,42 @@ final class SharedLogicTests: XCTestCase {
         XCTAssertFalse(PowerParsers.isSleepDisabled(pmsetG: "Currently in use:\n standby 1"))
     }
 
+    // MARK: PowerParsers.sleepDisabled — output that doesn't state the flag
+
+    func testStrictSleepDisabledReadsTheFlag() {
+        XCTAssertEqual(PowerParsers.sleepDisabled(pmsetG: " SleepDisabled        1"), true)
+        XCTAssertEqual(PowerParsers.sleepDisabled(pmsetG: " SleepDisabled        0"), false)
+    }
+
+    /// `pmset` failing usually means empty stdout, which must not read as "off" —
+    /// that would claim the Mac is free to sleep on the strength of no data.
+    func testStrictSleepDisabledIsUnknownWhenOutputIsEmpty() {
+        XCTAssertNil(PowerParsers.sleepDisabled(pmsetG: ""))
+    }
+
+    func testStrictSleepDisabledIsUnknownWhenKeyIsMissing() {
+        XCTAssertNil(PowerParsers.sleepDisabled(pmsetG: "Currently in use:\n standby 1"))
+    }
+
+    func testStrictSleepDisabledIsUnknownWhenValueIsMalformed() {
+        XCTAssertNil(PowerParsers.sleepDisabled(pmsetG: " SleepDisabled        yes"))
+        XCTAssertNil(PowerParsers.sleepDisabled(pmsetG: " SleepDisabled"))
+        XCTAssertNil(PowerParsers.sleepDisabled(pmsetG: " SleepDisabled        "))
+    }
+
+    /// Truncated output — the process died mid-write — states nothing.
+    func testStrictSleepDisabledIsUnknownWhenOutputIsTruncated() {
+        XCTAssertNil(PowerParsers.sleepDisabled(pmsetG: "System-wide power settings:\n Sleep"))
+    }
+
+    /// The lenient wrapper still exists for the helper's `Bool`-only XPC reply,
+    /// and must keep collapsing unknown to false rather than changing behaviour.
+    func testLenientFormCollapsesUnknownToFalse() {
+        XCTAssertFalse(PowerParsers.isSleepDisabled(pmsetG: ""))
+        XCTAssertFalse(PowerParsers.isSleepDisabled(pmsetG: " SleepDisabled        yes"))
+        XCTAssertTrue(PowerParsers.isSleepDisabled(pmsetG: " SleepDisabled        1"))
+    }
+
     // MARK: BatteryParsers
 
     func testBatteryOnAC() {

--- a/Tests/LidlessTests/StateReconcilerTests.swift
+++ b/Tests/LidlessTests/StateReconcilerTests.swift
@@ -1,0 +1,217 @@
+import XCTest
+
+/// Covers the decision logic behind issue #21: keeping the UI in step with the
+/// real `SleepDisabled` flag without ever asserting a state we haven't read.
+final class StateReconcilerTests: XCTestCase {
+
+    // MARK: Reconciling a fresh read
+
+    func testExternalEnableIsAdoptedAsDrift() {
+        XCTAssertEqual(StateReconciler.reconcile(shown: false, hasBaseline: true, observed: true),
+                       .drift(.enabledOutside))
+        XCTAssertTrue(ExternalChange.enabledOutside.nowEnabled)
+    }
+
+    func testExternalDisableInvalidatesStaleEnabledState() {
+        XCTAssertEqual(StateReconciler.reconcile(shown: true, hasBaseline: true, observed: false),
+                       .drift(.disabledOutside))
+        XCTAssertFalse(ExternalChange.disabledOutside.nowEnabled)
+    }
+
+    func testUnknownReadKeepsShownEnabledState() {
+        XCTAssertEqual(StateReconciler.reconcile(shown: true, hasBaseline: true, observed: nil), .unknown)
+    }
+
+    func testUnknownReadKeepsShownDisabledState() {
+        XCTAssertEqual(StateReconciler.reconcile(shown: false, hasBaseline: true, observed: nil), .unknown)
+    }
+
+    /// Guards idempotence: a steady-state poll must report nothing adoptable, or
+    /// every pass would re-arm the auto-off timer and restart the heartbeat.
+    func testAgreeingReadIsInSyncEvenWithoutBaseline() {
+        XCTAssertEqual(StateReconciler.reconcile(shown: true, hasBaseline: true, observed: true), .inSync)
+        XCTAssertEqual(StateReconciler.reconcile(shown: false, hasBaseline: true, observed: false), .inSync)
+        XCTAssertEqual(StateReconciler.reconcile(shown: false, hasBaseline: false, observed: false), .inSync)
+    }
+
+    func testFirstDifferingObservationAdoptsWithoutWarning() {
+        XCTAssertEqual(StateReconciler.reconcile(shown: false, hasBaseline: false, observed: true),
+                       .adopt(enabled: true))
+    }
+
+    func testFirstObservationUnknownStaysUnknown() {
+        XCTAssertEqual(StateReconciler.reconcile(shown: false, hasBaseline: false, observed: nil), .unknown)
+    }
+
+    /// End to end across the two pure layers: unreadable `pmset` output must
+    /// reach the reconciler as "unknown" and leave the shown state alone, rather
+    /// than parsing into a confident "off" that flips the toggle.
+    func testUnreadablePmsetOutputReconcilesToUnknown() {
+        for output in ["", "Currently in use:\n standby 1", " SleepDisabled        yes"] {
+            let observed = PowerParsers.sleepDisabled(pmsetG: output)
+            XCTAssertNil(observed, "\(output.debugDescription) states nothing about the flag")
+            XCTAssertEqual(StateReconciler.reconcile(shown: true, hasBaseline: true, observed: observed),
+                           .unknown)
+        }
+    }
+
+    // MARK: Stale replies — reads
+
+    func testFreshReadApplies() {
+        var sync = StateSync()
+        let token = sync.beginRead()
+        XCTAssertTrue(sync.shouldApply(token))
+    }
+
+    func testNewerReadInvalidatesTheOlderReply() {
+        var sync = StateSync()
+        let first = sync.beginRead()
+        let second = sync.beginRead()
+        XCTAssertFalse(sync.shouldApply(first), "an out-of-order reply must not win")
+        XCTAssertTrue(sync.shouldApply(second))
+    }
+
+    func testMutationInvalidatesAnInFlightRead() {
+        var sync = StateSync()
+        let read = sync.beginRead()
+        sync.beginMutation()
+        XCTAssertFalse(sync.shouldApply(read))
+    }
+
+    /// Two mutations put the value back where it started; comparing observed
+    /// values could never tell that anything happened, but the counter can.
+    func testABARoundTripStillInvalidatesTheRead() {
+        var sync = StateSync()
+        let read = sync.beginRead()
+        sync.beginMutation()
+        sync.beginMutation()
+        XCTAssertFalse(sync.shouldApply(read))
+    }
+
+    // MARK: Stale replies — writes
+
+    func testStaleWriteCompletionIsRejected() {
+        var sync = StateSync()
+        let first = sync.beginMutation()
+        let second = sync.beginMutation()
+        XCTAssertFalse(sync.shouldApply(first))
+        XCTAssertTrue(sync.shouldApply(second))
+    }
+
+    func testOutOfOrderWriteRepliesApplyOnlyTheLatest() {
+        var sync = StateSync()
+        let older = sync.beginMutation()
+        let newer = sync.beginMutation()
+        // The older write replies last; it must still lose.
+        XCTAssertTrue(sync.shouldApply(newer))
+        XCTAssertFalse(sync.shouldApply(older))
+    }
+
+    /// Both writes ask for the same target, so only the counter distinguishes
+    /// them — the payload is identical.
+    func testDuplicateTargetWritesStillInvalidateTheOlder() {
+        var sync = StateSync()
+        let first = sync.beginMutation()
+        let second = sync.beginMutation()
+        XCTAssertNotEqual(first, second)
+        XCTAssertFalse(sync.shouldApply(first))
+    }
+
+    func testABAWriteSequenceRejectsTheFirstCompletion() {
+        var sync = StateSync()
+        let on = sync.beginMutation()
+        sync.beginMutation()               // off
+        sync.beginMutation()               // on again
+        XCTAssertFalse(sync.shouldApply(on))
+    }
+
+    func testAdoptionInvalidatesAnInFlightWrite() {
+        var sync = StateSync()
+        let write = sync.beginMutation()
+        sync.beginMutation()               // a reconciled read adopting a new state
+        XCTAssertFalse(sync.shouldApply(write))
+    }
+
+    // MARK: Notice lifecycle
+
+    /// The regression test for external-enable followed by a low-battery pause:
+    /// the pause must not erase the notice that explains where the state came from.
+    func testOnlyUserActionClearsTheExternalNotice() {
+        XCTAssertTrue(StateReconciler.clearsExternalNotice(.user))
+        XCTAssertFalse(StateReconciler.clearsExternalNotice(.safety))
+        XCTAssertFalse(StateReconciler.clearsExternalNotice(.autoOff))
+    }
+
+    func testDriftMessagesDescribeTheEventNotTheResultingState() {
+        // Must stay true after a safety pause flips the state straight back, so
+        // it may not promise anything about what the Mac is doing now.
+        for change in [ExternalChange.enabledOutside, .disabledOutside] {
+            XCTAssertTrue(change.message.contains("outside Lidless"))
+            XCTAssertFalse(change.message.contains("will"))
+        }
+    }
+
+    // MARK: Verifying a write
+
+    func testVerifiedWhenReadBackMatchesTarget() {
+        XCTAssertEqual(StateReconciler.verifyAfterSet(target: true, observed: true), .verified)
+        XCTAssertEqual(StateReconciler.verifyAfterSet(target: false, observed: false), .verified)
+    }
+
+    /// A timed-out read-back must produce neither a false positive nor a false
+    /// negative — the write did report success, we just can't confirm it.
+    func testUnknownReadBackIsUnverifiedNotFailure() {
+        XCTAssertEqual(StateReconciler.verifyAfterSet(target: true, observed: nil), .unverified)
+        XCTAssertEqual(StateReconciler.verifyAfterSet(target: false, observed: nil), .unverified)
+    }
+
+    func testMismatchedReadBackReportsActualState() {
+        XCTAssertEqual(StateReconciler.verifyAfterSet(target: true, observed: false), .mismatch(actual: false))
+        XCTAssertEqual(StateReconciler.verifyAfterSet(target: false, observed: true), .mismatch(actual: true))
+    }
+
+    func testUnverifiedMessageDoesNotClaimSuccess() {
+        XCTAssertTrue(StateReconciler.unverifiedMessage(target: true).contains("Couldn’t confirm"))
+        XCTAssertTrue(StateReconciler.unverifiedMessage(target: false).contains("Couldn’t confirm"))
+        XCTAssertNotEqual(StateReconciler.unverifiedMessage(target: true),
+                          StateReconciler.unverifiedMessage(target: false))
+    }
+
+    // MARK: Resolving a pending verification
+
+    /// This is what stops the "couldn't confirm" caveat sticking forever.
+    func testPendingConfirmsOnMatchingFreshRead() {
+        let pending = PendingVerification(target: true)
+        XCTAssertEqual(StateReconciler.resolve(pending, observed: true), .confirmed)
+    }
+
+    /// We never confirmed our own write landed, so a later disagreement is a
+    /// write that didn't hold — not somebody else's doing.
+    func testPendingResolvesToWriteMismatchNotExternalDrift() {
+        let pending = PendingVerification(target: true)
+        XCTAssertEqual(StateReconciler.resolve(pending, observed: false), .writeMismatch(actual: false))
+
+        let pendingOff = PendingVerification(target: false)
+        XCTAssertEqual(StateReconciler.resolve(pendingOff, observed: true), .writeMismatch(actual: true))
+    }
+
+    func testPendingStaysUnverifiedWhenTheReadFailsAgain() {
+        let pending = PendingVerification(target: true)
+        XCTAssertEqual(StateReconciler.resolve(pending, observed: nil), .stillUnverified)
+    }
+
+    /// Pins the two channels apart: verification text must never read as an
+    /// accusation that something else changed the flag.
+    func testVerificationMessagesAreDistinctFromExternalChangeMessages() {
+        let external = [ExternalChange.enabledOutside.message, ExternalChange.disabledOutside.message]
+        let verification = [StateReconciler.unverifiedMessage(target: true),
+                            StateReconciler.unverifiedMessage(target: false),
+                            StateReconciler.writeMismatchMessage(actual: true),
+                            StateReconciler.writeMismatchMessage(actual: false)]
+
+        for message in verification {
+            XCTAssertFalse(external.contains(message))
+            XCTAssertFalse(message.contains("outside Lidless"))
+        }
+    }
+}


### PR DESCRIPTION
Addresses #21 — the menu-bar icon and **"Keep awake with lid closed"** toggle drift out of sync with the actual system `SleepDisabled` state.

## The problem

`refreshState()` ran at launch, on a helper unusable→usable transition, on `installHelper()`, and on a helper failure. That's all. The 30s `tick()` never called it, and there was no `onAppear` anywhere in `Sources/`. So anything else that moved the flag — `pmset` in Terminal, the helper's own watchdog auto-restore, another build of the app — left the UI stating something that wasn't true.

The issue is right that this is unsafe in both directions: a lid closed on a Mac that will sleep mid-build, or a MacBook bagged while it stays awake.

## Design

### "Unknown" had to be representable first

Reconciling against a failed read is worse than not reconciling at all — a 6s timeout read as "off" would flip the UI to off *while the Mac is actually staying awake*, which is precisely the dangerous direction. Three places quietly turned a failure into a confident `false`:

- `Shell.capture` ignored a non-zero exit, and a failed command's empty stdout parses as a perfectly plausible "flag is off".
- `PowerParsers.isSleepDisabled` returned `false` for output that never mentioned the flag, or mentioned it with a value that wasn't `0`/`1`.
- The helper's `getState` XPC reply is a plain `Bool`, so a `pmset` failure *inside the daemon* arrived indistinguishable from a real "off".

Reading `pmset -g` needs no privileges, so the app now reads it directly on every path and the helper is only used to *change* the flag. `HelperManager.getState` is deleted. **`LidlessHelperProtocol` is untouched — no helper reinstall.**

`Shell.capture` also now drains its pipe before `waitUntilExit()`; the old order would deadlock on output large enough to fill the buffer.

### Async replies carry tokens

A single in-flight flag can't order two concurrent reads (popover open plus the 30s tick), can't order two writes, and comparing observed values can't detect a repeated target or an on→off→on round trip at all — the value ends up where it started. `StateSync` uses monotonic read and mutation counters instead: a read applies only if it's the newest issued *and* nothing mutated since; a write completion applies only if it's still the newest mutation.

### A write's success reply is a claim, not a reading

It no longer sets the baseline. It opens a `PendingVerification`, and until a read resolves it the UI says plainly that the state isn't confirmed. A later disagreement while pending is reported as *our write not holding* — never attributed to an external actor we can't observe. This also means an unconfirmed write can't masquerade as external drift on the next tick.

### Three disjoint notice channels

| Slot | Set by | Cleared by |
|---|---|---|
| `externalNotice` | drift detected | a `.user` set only |
| `verificationNotice` | unverified / mismatched write | a confirming read, or any new write |
| `lastError` | safety notes, helper errors | as before |

`userInitiated: Bool` became a `SetOrigin` enum for this. A safety pause tripped by the very state we just adopted must not erase the notice explaining where that state came from — so `.safety` and `.autoOff` don't clear it, only `.user` does.

## What the issue suggested that this does differently

- **"Periodically while enabled"** — polls every tick instead. Gating on "while we think it's on" structurally misses the case where it was turned on behind our back, which is the bagged-laptop direction.
- **"Read back after every setKeepAwake"** — correct, but unsafe until `getState` could say "I don't know"; hence the work above.
- **Warning on every mismatch** — the first read of a session isn't a change. A relaunch inside the watchdog's 90s window would otherwise accuse someone of something that never happened, so the first differing read adopts silently.

## Verification

Local gates per `CLAUDE.md` (CI is down):

```
xcodegen generate                                            ✓
xcodebuild test -scheme Lidless-CI ...   ** TEST SUCCEEDED **   70/70 (37 existing + 33 new)
xcodebuild build -scheme Lidless ...     ** BUILD SUCCEEDED **  (separate -derivedDataPath)
```

No `project.yml` change: `StateReconciler.swift` lives in `Sources/Shared`, already a source of all three targets.

New tests cover the reconciler, the token guard (stale reads, stale write completions, out-of-order replies, duplicate targets, ABA, adoption superseding a write), the notice lifecycle, pending resolution, and every shape of `pmset` output that states nothing.

## Manual QA — NOT YET RUN

The test bundle can't link the app target (Sparkle), so all automated tests are over the pure logic in `Sources/Shared`. The wiring inside `AppState`, and `Shell.capture`'s exit-status handling, are compiler-checked only. These need a human:

- [ ] **UI off / system on.** Toggle off, `sudo pmset -a disablesleep 1`, confirm `pmset -g | grep SleepDisabled` → `1`. Within 30s or on opening the popover: icon active, toggle on, orange banner. Flip off → banner clears, flag → `0`.
- [ ] **UI on / system off.** Toggle on, `sudo pmset -a disablesleep 0`. Popover or ≤30s: toggle off, icon inactive, banner. Flip on → banner clears, flag → `1`.
- [ ] **External enable on low battery.** Banner **and** safety reason both visible; flag ends at `0`.
- [ ] **Unconfirmed write, then confirmation.** Make the helper slow/unreachable while the read-back is in flight so the caveat appears; restore it and wait a tick — the caveat must **clear**, not persist.
- [ ] **Normal toggling** with the popover open: no banner, no caveat, no flicker.
- [ ] **Unknown path.** With keep-awake on, `sudo launchctl bootout system/com.nghialuong.lidless.dev.helper` — the toggle must **not** silently drop to off.
- [ ] **Launch baseline.** Quit, `sudo pmset -a disablesleep 1`, relaunch: shows on with **no** banner.
- [ ] Cleanup: `sudo pmset -a disablesleep 0`.

Run against the Debug build (`com.nghialuong.lidless.dev`, separate defaults from the released app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)