### PR TITLE
fix: settle auto-enable against the reconciled state machine

### DIFF
--- a/Sources/Lidless/AppState.swift
+++ b/Sources/Lidless/AppState.swift
@@ -28,6 +28,30 @@ final class AppState: ObservableObject {
     /// User-tunable safety preferences (persisted).
     @Published var settings: SafetySettings = .default
 
+    /// Auto-mode master-toggle intent (persisted): whether the user wants
+    /// keep-awake armed. In auto mode the *live* state (`isEnabled`) is derived
+    /// from `armed` gated by power + safety; in manual mode this simply mirrors
+    /// `isEnabled`. See `reconcile()`.
+    @Published var armed = false
+
+    /// The currently-unmet checks to surface in the popover's auto-mode warning,
+    /// or empty when there's nothing to warn about. Non-empty only when auto mode
+    /// is on, the feature is armed, but keep-awake isn't live right now.
+    var autoWarningReasons: [SafetyReason] {
+        guard settings.autoEnableWhenCharging, armed, !isEnabled else { return [] }
+        let info = BatteryInfo(percent: batteryPercent, onAC: batteryOnAC)
+        return SafetyEvaluator.allUnmetReasons(battery: info,
+                                               thermalSerious: thermalSerious(),
+                                               settings: settings,
+                                               requirePower: true)
+    }
+
+    /// The value the main "Keep awake with lid closed" toggle should show: the
+    /// armed intent in auto mode, the live state in manual mode.
+    var masterToggleOn: Bool {
+        settings.autoEnableWhenCharging ? armed : isEnabled
+    }
+
     /// Launch-at-login state (the app itself).
     @Published var launchAtLogin = false
 
@@ -91,6 +115,7 @@ final class AppState: ObservableObject {
 
     init() {
         settings = store.load()
+        armed = store.loadArmed()
         autoOffMinutes = store.loadAutoOffMinutes()
         onboardingComplete = store.loadOnboardingComplete()
         launchAtLogin = loginItem.isEnabled
@@ -99,6 +124,11 @@ final class AppState: ObservableObject {
         helperWasUsable = usingHelper
         refreshState()
         refreshBattery()
+        // Auto mode owns the live state at launch: (re-)activate if armed and
+        // conditions allow, or force it off otherwise (in case a prior session
+        // left it on). `force` because the async `refreshState()` above may not
+        // have reported the real state back yet.
+        if settings.autoEnableWhenCharging { reconcile(force: true) }
         batteryTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
             Task { @MainActor in self?.tick() }
         }
@@ -159,9 +189,53 @@ final class AppState: ObservableObject {
     }
 
     func updateSettings(_ new: SafetySettings) {
+        let wasAuto = settings.autoEnableWhenCharging
         settings = new
         store.save(new)
-        evaluateSafety()
+        if new.autoEnableWhenCharging {
+            if !wasAuto {
+                // Entering auto mode: seed the armed intent from the current live
+                // state, and drop any manual auto-off countdown (auto mode manages
+                // activation itself, so a countdown would just fight it).
+                armed = isEnabled
+                store.saveArmed(armed)
+                cancelAutoOff()
+            }
+            reconcile()
+        } else {
+            evaluateSafety()
+        }
+    }
+
+    /// The main toggle was flipped. In auto mode it sets the armed intent (and
+    /// lets `reconcile()` gate the live state); in manual mode it directly turns
+    /// keep-awake on/off, surfacing any failure/refusal as an alert.
+    func setMasterToggle(_ on: Bool) {
+        if settings.autoEnableWhenCharging {
+            setArmed(on)
+        } else {
+            setEnabled(on, userInitiated: true)
+        }
+    }
+
+    /// Set the auto-mode armed intent, persist it, and reconcile the live state.
+    private func setArmed(_ on: Bool) {
+        armed = on
+        store.saveArmed(on)
+        reconcile()
+    }
+
+    /// Auto mode: derive the live keep-awake state from `armed` gated by external
+    /// power + safety, flipping only the live state (never the `armed` intent) and
+    /// without alerts. When conditions aren't met the feature stays armed and the
+    /// popover's warning explains why it isn't currently active.
+    func reconcile(force: Bool = false) {
+        guard settings.autoEnableWhenCharging else { return }
+        let shouldBeOn = armed && AutoEnablePolicy.canActivate(battery: battery.read(),
+                                                               thermalSerious: thermalSerious(),
+                                                               settings: settings)
+        guard force || shouldBeOn != isEnabled else { return }
+        setEnabled(shouldBeOn, note: nil)
     }
 
     /// Change the auto-off duration. Re-arms (or cancels) the live timer when
@@ -565,7 +639,9 @@ final class AppState: ObservableObject {
 
     private func armAutoOff() {
         cancelAutoOff()
-        guard isEnabled, autoOffMinutes > 0 else { return }
+        // Auto mode manages activation on its own; a countdown would disarm the
+        // feature out from under it, so auto-off is inert while auto mode is on.
+        guard isEnabled, autoOffMinutes > 0, !settings.autoEnableWhenCharging else { return }
         let deadline = AutoOff.deadline(from: Date(), minutes: autoOffMinutes)
         autoOffDeadline = deadline
         refreshAutoOffRemaining()
@@ -612,7 +688,11 @@ final class AppState: ObservableObject {
         // where it was turned on behind our back.
         refreshState()
         refreshBattery()
-        evaluateSafety()
+        if settings.autoEnableWhenCharging {
+            reconcile()
+        } else {
+            evaluateSafety()
+        }
     }
 
     func refreshBattery() {

--- a/Sources/Lidless/AppState.swift
+++ b/Sources/Lidless/AppState.swift
@@ -129,6 +129,10 @@ final class AppState: ObservableObject {
         // conditions since lapsed. `refreshState()` above reads the flag
         // synchronously, so `isEnabled` is already the real state to compare
         // against and there's nothing to force.
+        //
+        // Plainly `reconcile()`, not `reconcileNow()`: adopting the state that
+        // read just established may already have dispatched a write, and clearing
+        // that claim here would dispatch a second one for the same decision.
         reconcile()
         batteryTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
             Task { @MainActor in self?.tick() }
@@ -205,7 +209,7 @@ final class AppState: ObservableObject {
                 store.saveArmed(armed)
                 cancelAutoOff()
             }
-            reconcile()
+            reconcileNow()
         } else {
             // Leaving auto mode hands activation back to the user, so the auto-off
             // countdown becomes applicable again — re-arm it if one is configured
@@ -230,7 +234,7 @@ final class AppState: ObservableObject {
     private func setArmed(_ on: Bool) {
         armed = on
         store.saveArmed(on)
-        reconcile()
+        reconcileNow()
     }
 
     /// Auto mode: derive the live keep-awake state from `armed` gated by external
@@ -240,27 +244,35 @@ final class AppState: ObservableObject {
     ///
     /// Refreshes the battery cache first so the decision and the warning list the
     /// popover renders from it are read off the same sample. No-ops when auto mode
-    /// is off or the live state already matches — `origin: .auto` because this
-    /// fires unprompted on the poll timer and must stay silent.
+    /// is off, when the live state already matches, or while an earlier write is
+    /// still outstanding or has already concluded this turn — see `autoWrite`.
+    /// `origin: .auto` because this fires unprompted on the poll timer and must
+    /// stay silent.
     func reconcile() {
-        guard settings.autoEnableWhenCharging, !reconciling else { return }
-        reconciling = true
-        defer { reconciling = false }
+        guard settings.autoEnableWhenCharging, autoWrite.mayWrite else { return }
         refreshBattery()
         guard let target = AutoEnablePolicy.target(armed: armed,
                                                    currentlyEnabled: isEnabled,
                                                    battery: currentBattery,
                                                    thermalSerious: thermalSerious(),
                                                    settings: settings) else { return }
+        autoWrite.issued(target: target)
         setEnabled(target, note: nil, origin: .auto)
     }
 
-    /// Guards against re-entering `reconcile()` from inside its own write. The
-    /// read-back in `setEnabled` is synchronous, so a write that never lands
-    /// resolves as a mismatch, adopts the unchanged state, and would ask us to
-    /// write again — recursing until the stack runs out. One pass per call is
-    /// always enough: the next poll tick retries.
-    private var reconciling = false
+    /// Reconcile now, discarding any deferral left by an earlier write this turn.
+    /// For the paths the user just drove — arming, changing settings — where
+    /// waiting for the next tick would read as the control doing nothing. A write
+    /// still in flight is superseded, which is what the user just asked for.
+    private func reconcileNow() {
+        autoWrite.clear()
+        reconcile()
+    }
+
+    /// The claim on auto mode's outstanding write. Held across the helper's async
+    /// round trip, so a reply that reads back wrong can't immediately provoke
+    /// another write. See `AutoWriteCoordinator`.
+    private var autoWrite = AutoWriteCoordinator()
 
     /// The last-sampled battery state, refreshed by `refreshBattery()`. Shared by
     /// `reconcile()` and `autoWarningReasons` so the two can't disagree.
@@ -441,10 +453,15 @@ final class AppState: ObservableObject {
             case .stillUnverified:
                 break
             case .confirmed:
+                autoWrite.resolved()
                 pendingVerification = nil
                 verificationNotice = nil
                 hasConfirmedState = true
             case .writeMismatch(let actual):
+                // Same ordering rule as `applyVerification`: settle the claim
+                // before adopting, so the reconcile that adopting triggers can't
+                // chase the mismatch with another write in this turn.
+                autoWrite.resolved()
                 pendingVerification = nil
                 verificationNotice = StateReconciler.writeMismatchMessage(actual: actual)
                 hasConfirmedState = true
@@ -505,6 +522,11 @@ final class AppState: ObservableObject {
     /// unnoticed; background callers pass their own origin to stay quiet.
     func setEnabled(_ target: Bool, note: String? = nil, origin: SetOrigin = .user) {
         if StateReconciler.clearsExternalNotice(origin) { externalNotice = nil }
+        // Any other origin takes the flag away from auto mode: its claim is void
+        // and its reply, if one is still in flight, will be rejected as superseded
+        // below. Leaving the claim standing would wedge auto mode until the next
+        // tick on a reply that is never coming.
+        if origin != .auto { autoWrite.clear() }
 
         // Refuse to enable if it would immediately violate the safety policy.
         // Returns before claiming a mutation, so nothing in flight is disturbed.
@@ -517,6 +539,9 @@ final class AppState: ObservableObject {
                 if origin == .user {
                     presentFailureAlert(target: target, message: blocker.blockedMessage)
                 }
+                // Nothing was dispatched, so release the claim rather than holding
+                // it for a write that never happened.
+                if origin == .auto { autoWrite.clear() }
                 return
             }
         }
@@ -574,6 +599,10 @@ final class AppState: ObservableObject {
     /// the flag did move, that was our own failed write, and blaming an external
     /// actor for it would be plainly wrong.
     private func recoverStateAfterFailedWrite() {
+        // Resolve before re-reading: that read can adopt a state and ask auto mode
+        // to reconcile, which must not turn into an immediate second attempt at
+        // the write that just failed.
+        autoWrite.resolved()
         hasConfirmedState = false
         refreshState()
     }
@@ -590,6 +619,12 @@ final class AppState: ObservableObject {
     /// Verification never writes to `lastError`: it keeps its own channel so
     /// clearing a caveat can't wipe a safety note or a helper error.
     private func applyVerification(_ outcome: StateReconciler.VerifyOutcome, target: Bool) {
+        // Whatever the outcome, auto mode's write is over. Resolving up front
+        // matters most for `.mismatch`, where adopting the contradicting state
+        // reconciles again: without this, that reconcile would dispatch a fresh
+        // write, whose read-back could mismatch in turn, with no bound but the
+        // stack. Deferring costs one tick and cannot loop.
+        autoWrite.resolved()
         switch outcome {
         case .verified:
             pendingVerification = nil
@@ -721,6 +756,10 @@ final class AppState: ObservableObject {
         // Backstop for the didBecomeActive observer: catch a helper approval even
         // if the app never lost/regained active state.
         recheckHelper()
+        // A fresh tick releases any claim auto mode is still holding — including
+        // one whose reply was superseded and will never arrive — so a deferred or
+        // abandoned write always gets another chance here and nowhere earlier.
+        autoWrite.clear()
         // Reconcile with the real flag every tick, not only while enabled:
         // polling only when we think it's on would structurally miss the case
         // where it was turned on behind our back.

--- a/Sources/Lidless/AppState.swift
+++ b/Sources/Lidless/AppState.swift
@@ -30,8 +30,9 @@ final class AppState: ObservableObject {
 
     /// Auto-mode master-toggle intent (persisted): whether the user wants
     /// keep-awake armed. In auto mode the *live* state (`isEnabled`) is derived
-    /// from `armed` gated by power + safety; in manual mode this simply mirrors
-    /// `isEnabled`. See `reconcile()`.
+    /// from `armed` gated by power + safety — see `reconcile()`. Unused in manual
+    /// mode, where the toggle drives `isEnabled` directly; it's (re-)seeded on the
+    /// way into auto mode rather than tracked continuously.
     @Published var armed = false
 
     /// The currently-unmet checks to surface in the popover's auto-mode warning,
@@ -39,8 +40,7 @@ final class AppState: ObservableObject {
     /// is on, the feature is armed, but keep-awake isn't live right now.
     var autoWarningReasons: [SafetyReason] {
         guard settings.autoEnableWhenCharging, armed, !isEnabled else { return [] }
-        let info = BatteryInfo(percent: batteryPercent, onAC: batteryOnAC)
-        return SafetyEvaluator.allUnmetReasons(battery: info,
+        return SafetyEvaluator.allUnmetReasons(battery: currentBattery,
                                                thermalSerious: thermalSerious(),
                                                settings: settings,
                                                requirePower: true)
@@ -125,10 +125,11 @@ final class AppState: ObservableObject {
         refreshState()
         refreshBattery()
         // Auto mode owns the live state at launch: (re-)activate if armed and
-        // conditions allow, or force it off otherwise (in case a prior session
-        // left it on). `force` because the async `refreshState()` above may not
-        // have reported the real state back yet.
-        if settings.autoEnableWhenCharging { reconcile(force: true) }
+        // conditions allow, or turn it off if a prior session left it on with
+        // conditions since lapsed. `refreshState()` above reads the flag
+        // synchronously, so `isEnabled` is already the real state to compare
+        // against and there's nothing to force.
+        reconcile()
         batteryTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
             Task { @MainActor in self?.tick() }
         }
@@ -194,15 +195,22 @@ final class AppState: ObservableObject {
         store.save(new)
         if new.autoEnableWhenCharging {
             if !wasAuto {
-                // Entering auto mode: seed the armed intent from the current live
-                // state, and drop any manual auto-off countdown (auto mode manages
-                // activation itself, so a countdown would just fight it).
-                armed = isEnabled
+                // Opting into auto mode *is* the request to have keep-awake on, so
+                // arm it rather than inheriting the current live state — otherwise
+                // switching on "Automatically enable when charging" while
+                // keep-awake happens to be off (the very case this feature exists
+                // for) would visibly do nothing. Also drop any manual auto-off
+                // countdown, which would just fight auto mode's own activation.
+                armed = true
                 store.saveArmed(armed)
                 cancelAutoOff()
             }
             reconcile()
         } else {
+            // Leaving auto mode hands activation back to the user, so the auto-off
+            // countdown becomes applicable again — re-arm it if one is configured
+            // and keep-awake is currently on.
+            if wasAuto, isEnabled { armAutoOff() }
             evaluateSafety()
         }
     }
@@ -214,7 +222,7 @@ final class AppState: ObservableObject {
         if settings.autoEnableWhenCharging {
             setArmed(on)
         } else {
-            setEnabled(on, userInitiated: true)
+            setEnabled(on, origin: .user)
         }
     }
 
@@ -226,16 +234,38 @@ final class AppState: ObservableObject {
     }
 
     /// Auto mode: derive the live keep-awake state from `armed` gated by external
-    /// power + safety, flipping only the live state (never the `armed` intent) and
-    /// without alerts. When conditions aren't met the feature stays armed and the
-    /// popover's warning explains why it isn't currently active.
-    func reconcile(force: Bool = false) {
-        guard settings.autoEnableWhenCharging else { return }
-        let shouldBeOn = armed && AutoEnablePolicy.canActivate(battery: battery.read(),
-                                                               thermalSerious: thermalSerious(),
-                                                               settings: settings)
-        guard force || shouldBeOn != isEnabled else { return }
-        setEnabled(shouldBeOn, note: nil)
+    /// power + safety, flipping only the live state (never the `armed` intent).
+    /// When conditions aren't met the feature stays armed and the popover's
+    /// warning explains why it isn't currently active.
+    ///
+    /// Refreshes the battery cache first so the decision and the warning list the
+    /// popover renders from it are read off the same sample. No-ops when auto mode
+    /// is off or the live state already matches — `origin: .auto` because this
+    /// fires unprompted on the poll timer and must stay silent.
+    func reconcile() {
+        guard settings.autoEnableWhenCharging, !reconciling else { return }
+        reconciling = true
+        defer { reconciling = false }
+        refreshBattery()
+        guard let target = AutoEnablePolicy.target(armed: armed,
+                                                   currentlyEnabled: isEnabled,
+                                                   battery: currentBattery,
+                                                   thermalSerious: thermalSerious(),
+                                                   settings: settings) else { return }
+        setEnabled(target, note: nil, origin: .auto)
+    }
+
+    /// Guards against re-entering `reconcile()` from inside its own write. The
+    /// read-back in `setEnabled` is synchronous, so a write that never lands
+    /// resolves as a mismatch, adopts the unchanged state, and would ask us to
+    /// write again — recursing until the stack runs out. One pass per call is
+    /// always enough: the next poll tick retries.
+    private var reconciling = false
+
+    /// The last-sampled battery state, refreshed by `refreshBattery()`. Shared by
+    /// `reconcile()` and `autoWarningReasons` so the two can't disagree.
+    private var currentBattery: BatteryInfo {
+        BatteryInfo(percent: batteryPercent, onAC: batteryOnAC)
     }
 
     /// Change the auto-off duration. Re-arms (or cancels) the live timer when
@@ -453,7 +483,15 @@ final class AppState: ObservableObject {
         sync.beginMutation()            // supersede every read and write still in flight
         manageHeartbeat()
         updateAutoOff(for: enabled)
-        if enabled { evaluateSafety() }
+        // Auto mode owns the live state, so route through `reconcile()` rather
+        // than the manual safety pass: adopting an outside change must be settled
+        // by the same rule that set the state in the first place, or the toggle
+        // visibly jumps and then falls back a tick later.
+        if settings.autoEnableWhenCharging {
+            reconcile()
+        } else if enabled {
+            evaluateSafety()
+        }
     }
 
     /// User flipped the toggle: `.user` origin so any failure or refusal surfaces
@@ -687,10 +725,10 @@ final class AppState: ObservableObject {
         // polling only when we think it's on would structurally miss the case
         // where it was turned on behind our back.
         refreshState()
-        refreshBattery()
         if settings.autoEnableWhenCharging {
-            reconcile()
+            reconcile()             // refreshes the battery sample itself
         } else {
+            refreshBattery()
             evaluateSafety()
         }
     }

--- a/Sources/Lidless/AppState.swift
+++ b/Sources/Lidless/AppState.swift
@@ -226,12 +226,16 @@ final class AppState: ObservableObject {
             // in `settings` by now, so the countdown arms exactly as manual mode
             // expects.
             refreshBattery()
+            let conditions = SafetySnapshot(battery: currentBattery,
+                                            thermalSerious: thermalSerious())
             let settled = AutoEnablePolicy.handoffToManual(pendingTarget: pending,
-                                                           battery: currentBattery,
-                                                           thermalSerious: thermalSerious(),
+                                                           conditions: conditions,
                                                            settings: settings)
             autoWrite.clear()
-            setEnabled(settled, note: nil, origin: .auto)
+            // Same snapshot to decide and to write: whichever way `settled` went,
+            // the check on the way out is guaranteed to permit it, so this write
+            // always claims a mutation and always supersedes the auto reply.
+            setEnabled(settled, note: nil, origin: .auto, conditions: conditions)
         } else {
             // Leaving auto mode hands activation back to the user, so the auto-off
             // countdown becomes applicable again — re-arm it if one is configured
@@ -297,6 +301,12 @@ final class AppState: ObservableObject {
         guard settings.autoEnableWhenCharging else { return }
         guard userDriven || autoWrite.mayWrite else { return }
         refreshBattery()
+        // One sample, used to decide *and* handed to the write, so the check on
+        // the way out can't disagree with the decision that authorised it. A
+        // disagreement there would be a refusal, and a refusal claims no mutation
+        // — leaving a superseded write in force.
+        let conditions = SafetySnapshot(battery: currentBattery,
+                                        thermalSerious: thermalSerious())
         let effective = AutoEnablePolicy.effectiveState(pendingTarget: autoWrite.inFlightTarget,
                                                         live: isEnabled)
         // No target means the outstanding write is already heading where we want
@@ -304,11 +314,11 @@ final class AppState: ObservableObject {
         // would let the next tick dispatch a duplicate alongside a live request.
         guard let target = AutoEnablePolicy.target(armed: armed,
                                                    currentlyEnabled: effective,
-                                                   battery: currentBattery,
-                                                   thermalSerious: thermalSerious(),
+                                                   battery: conditions.battery,
+                                                   thermalSerious: conditions.thermalSerious,
                                                    settings: settings) else { return }
         autoWrite.issued(target: target)
-        setEnabled(target, note: nil, origin: .auto)
+        setEnabled(target, note: nil, origin: .auto, conditions: conditions)
     }
 
     /// The claim on auto mode's outstanding write. Held across the helper's async
@@ -562,7 +572,16 @@ final class AppState: ObservableObject {
     /// any prior message. When `origin` is `.user` (the user flipped the toggle),
     /// a failure or policy refusal also pops a blocking alert so it can't go
     /// unnoticed; background callers pass their own origin to stay quiet.
-    func setEnabled(_ target: Bool, note: String? = nil, origin: SetOrigin = .user) {
+    /// `conditions` is the sample a caller already made its decision from. The
+    /// safety check below still runs — this is not a bypass — but it runs against
+    /// those conditions rather than a fresh reading, so a decision and the write
+    /// it authorises can't be judged against different worlds. Callers that have
+    /// no decision to be consistent with (the user flipping the switch) omit it
+    /// and get the fresh reading, which is what they want.
+    func setEnabled(_ target: Bool,
+                    note: String? = nil,
+                    origin: SetOrigin = .user,
+                    conditions: SafetySnapshot? = nil) {
         if StateReconciler.clearsExternalNotice(origin) { externalNotice = nil }
         // Any other origin takes the flag away from auto mode: its claim is void
         // and its reply, if one is still in flight, will be rejected as superseded
@@ -571,11 +590,14 @@ final class AppState: ObservableObject {
         if origin != .auto { autoWrite.clear() }
 
         // Refuse to enable if it would immediately violate the safety policy.
-        // Returns before claiming a mutation, so nothing in flight is disturbed.
+        // Returns before claiming a mutation, so nothing in flight is disturbed —
+        // which is exactly why a caller correcting an outstanding write must pass
+        // the conditions it decided from: a refusal here supersedes nothing.
         if target {
-            let info = battery.read()
-            if let blocker = SafetyEvaluator.reasonToDisable(battery: info,
-                                                             thermalSerious: thermalSerious(),
+            let checked = conditions ?? SafetySnapshot(battery: battery.read(),
+                                                       thermalSerious: thermalSerious())
+            if let blocker = SafetyEvaluator.reasonToDisable(battery: checked.battery,
+                                                             thermalSerious: checked.thermalSerious,
                                                              settings: settings) {
                 lastError = blocker.message
                 if origin == .user {

--- a/Sources/Lidless/AppState.swift
+++ b/Sources/Lidless/AppState.swift
@@ -524,8 +524,8 @@ final class AppState: ObservableObject {
         if StateReconciler.clearsExternalNotice(origin) { externalNotice = nil }
         // Any other origin takes the flag away from auto mode: its claim is void
         // and its reply, if one is still in flight, will be rejected as superseded
-        // below. Leaving the claim standing would wedge auto mode until the next
-        // tick on a reply that is never coming.
+        // below. Leaving the claim standing would stall auto mode for a tick or
+        // two on a reply that is never coming.
         if origin != .auto { autoWrite.clear() }
 
         // Refuse to enable if it would immediately violate the safety policy.
@@ -623,7 +623,7 @@ final class AppState: ObservableObject {
         // matters most for `.mismatch`, where adopting the contradicting state
         // reconciles again: without this, that reconcile would dispatch a fresh
         // write, whose read-back could mismatch in turn, with no bound but the
-        // stack. Deferring costs one tick and cannot loop.
+        // stack. Deferring costs a tick and cannot loop.
         autoWrite.resolved()
         switch outcome {
         case .verified:
@@ -756,10 +756,12 @@ final class AppState: ObservableObject {
         // Backstop for the didBecomeActive observer: catch a helper approval even
         // if the app never lost/regained active state.
         recheckHelper()
-        // A fresh tick releases any claim auto mode is still holding — including
-        // one whose reply was superseded and will never arrive — so a deferred or
-        // abandoned write always gets another chance here and nowhere earlier.
-        autoWrite.clear()
+        // Advance auto mode's write claim. A concluded write reopens here — this
+        // is where its retry comes from. One still outstanding does not: this tick
+        // may be landing moments after the dispatch, and reopening would put a
+        // second write alongside a live first. It reopens a tick later instead,
+        // which also bounds how long a lost reply can hold the feature.
+        autoWrite.advanceTick()
         // Reconcile with the real flag every tick, not only while enabled:
         // polling only when we think it's on would structurally miss the case
         // where it was turned on behind our back.

--- a/Sources/Lidless/AppState.swift
+++ b/Sources/Lidless/AppState.swift
@@ -210,6 +210,28 @@ final class AppState: ObservableObject {
                 cancelAutoOff()
             }
             reconcileNow()
+        } else if let pending = autoWrite.inFlightTarget {
+            // Leaving auto mode with a write still travelling. Its target is where
+            // the system is heading, so that's what manual mode inherits — but the
+            // transition has to own that outcome with a write of its own, or the
+            // auto reply lands afterwards and moves the state in a mode the user
+            // has already left.
+            //
+            // Quiet origin deliberately: the user toggled a mode, not the switch,
+            // so a modal about keep-awake would be about a write they never asked
+            // for. It also can't be `.user` for a second reason — that origin
+            // clears `externalNotice`, which this isn't entitled to do.
+            //
+            // The reply to this write runs `updateAutoOff`, and auto mode is off
+            // in `settings` by now, so the countdown arms exactly as manual mode
+            // expects.
+            refreshBattery()
+            let settled = AutoEnablePolicy.handoffToManual(pendingTarget: pending,
+                                                           battery: currentBattery,
+                                                           thermalSerious: thermalSerious(),
+                                                           settings: settings)
+            autoWrite.clear()
+            setEnabled(settled, note: nil, origin: .auto)
         } else {
             // Leaving auto mode hands activation back to the user, so the auto-off
             // countdown becomes applicable again — re-arm it if one is configured
@@ -242,31 +264,51 @@ final class AppState: ObservableObject {
     /// When conditions aren't met the feature stays armed and the popover's
     /// warning explains why it isn't currently active.
     ///
+    /// The poll's entry point. No-ops when auto mode is off, when the effective
+    /// state already matches, or while an earlier write is still outstanding or
+    /// has already concluded this turn — see `autoWrite`. `origin: .auto` because
+    /// this fires unprompted on the timer and must stay silent.
+    func reconcile() { reconcile(userDriven: false) }
+
+    /// Reconcile now on behalf of something the user just did — arming, changing
+    /// settings — where waiting for the next tick would read as the control doing
+    /// nothing.
+    ///
+    /// Unlike the poll, this may write over a request still in flight, because
+    /// the user has since said something newer. It does *not* simply drop the
+    /// claim: dropping it loses the pending target, and the decision is then
+    /// taken against a state the system has already left. Disarming while an
+    /// "on" write is travelling would compare `false` against a still-`false`
+    /// `isEnabled`, conclude there was nothing to do, and leave the earlier write
+    /// to land unopposed — turning keep-awake on moments after the user turned it
+    /// off. Deciding against the effective state instead yields a corrective
+    /// write, which supersedes the old reply and, because the helper serialises,
+    /// lands last.
+    private func reconcileNow() { reconcile(userDriven: true) }
+
+    /// Derive the live keep-awake state from `armed` gated by external power +
+    /// safety, flipping only the live state (never the `armed` intent). When
+    /// conditions aren't met the feature stays armed and the popover's warning
+    /// explains why it isn't currently active.
+    ///
     /// Refreshes the battery cache first so the decision and the warning list the
-    /// popover renders from it are read off the same sample. No-ops when auto mode
-    /// is off, when the live state already matches, or while an earlier write is
-    /// still outstanding or has already concluded this turn — see `autoWrite`.
-    /// `origin: .auto` because this fires unprompted on the poll timer and must
-    /// stay silent.
-    func reconcile() {
-        guard settings.autoEnableWhenCharging, autoWrite.mayWrite else { return }
+    /// popover renders from it are read off the same sample.
+    private func reconcile(userDriven: Bool) {
+        guard settings.autoEnableWhenCharging else { return }
+        guard userDriven || autoWrite.mayWrite else { return }
         refreshBattery()
+        let effective = AutoEnablePolicy.effectiveState(pendingTarget: autoWrite.inFlightTarget,
+                                                        live: isEnabled)
+        // No target means the outstanding write is already heading where we want
+        // it to. Leave the claim standing rather than clearing it — clearing
+        // would let the next tick dispatch a duplicate alongside a live request.
         guard let target = AutoEnablePolicy.target(armed: armed,
-                                                   currentlyEnabled: isEnabled,
+                                                   currentlyEnabled: effective,
                                                    battery: currentBattery,
                                                    thermalSerious: thermalSerious(),
                                                    settings: settings) else { return }
         autoWrite.issued(target: target)
         setEnabled(target, note: nil, origin: .auto)
-    }
-
-    /// Reconcile now, discarding any deferral left by an earlier write this turn.
-    /// For the paths the user just drove — arming, changing settings — where
-    /// waiting for the next tick would read as the control doing nothing. A write
-    /// still in flight is superseded, which is what the user just asked for.
-    private func reconcileNow() {
-        autoWrite.clear()
-        reconcile()
     }
 
     /// The claim on auto mode's outstanding write. Held across the helper's async

--- a/Sources/Lidless/MenuContent.swift
+++ b/Sources/Lidless/MenuContent.swift
@@ -32,6 +32,12 @@ struct MenuContent: View {
             PrimaryToggleRow()
                 .padding(.horizontal, hInset)
 
+            if !state.autoWarningReasons.isEmpty {
+                AutoDisabledWarning(reasons: state.autoWarningReasons)
+                    .padding(.horizontal, hInset)
+                    .padding(.bottom, 10)
+            }
+
             Divider()
                 .padding(.horizontal, hInset)
 
@@ -73,6 +79,14 @@ struct MenuContent: View {
                 .padding(.horizontal, hInset)
 
             SafetySection()
+                .padding(.horizontal, hInset)
+                .padding(.top, 12)
+
+            Divider()
+                .padding(.horizontal, hInset)
+                .padding(.top, 12)
+
+            AutomaticSection()
                 .padding(.horizontal, hInset)
                 .padding(.top, 12)
 
@@ -142,8 +156,8 @@ private struct PrimaryToggleRow: View {
                    titleFont: .body.weight(.semibold),
                    minHeight: 42) {
             Toggle("Keep awake with lid closed", isOn: Binding(
-                get: { state.isEnabled },
-                set: { _ in state.toggle() }
+                get: { state.masterToggleOn },
+                set: { state.setMasterToggle($0) }
             ))
             .labelsHidden()
             .toggleStyle(.switch)
@@ -228,18 +242,114 @@ private struct SafetySection: View {
                 .controlSize(.small)
             }
 
-            SettingRow(title: "Low-battery cutoff") {
-                HStack(spacing: 6) {
-                    Text("\(state.settings.lowBatteryThreshold)%")
+            LowBatteryCutoffRow()
+        }
+    }
+}
+
+/// Full-width low-battery cutoff slider (0–100%, step 1). `0` means "Never" —
+/// the low-battery check is disabled entirely.
+private struct LowBatteryCutoffRow: View {
+    @EnvironmentObject var state: AppState
+
+    private var threshold: Int { state.settings.lowBatteryThreshold }
+
+    /// The cutoff is meaningless while "Only while charging" is on (keep-awake is
+    /// already blocked whenever off power), so the row is disabled/greyed then.
+    private var isInactive: Bool { state.settings.onlyWhileCharging }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 12) {
+                Text("Low-battery cutoff")
+                    .font(.callout)
+                    .lineLimit(1)
+                Spacer(minLength: 16)
+                Text(threshold == 0 ? "Never" : "\(threshold)%")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+
+            Slider(
+                value: Binding(
+                    get: { Double(threshold) },
+                    set: { v in var s = state.settings; s.lowBatteryThreshold = Int(v.rounded()); state.updateSettings(s) }
+                ),
+                in: 0...100,
+                step: 5
+            ) {
+                Text("Low-battery cutoff")
+            } minimumValueLabel: {
+                Text("Never").font(.caption2).foregroundStyle(.secondary)
+            } maximumValueLabel: {
+                Text("100%").font(.caption2).foregroundStyle(.secondary)
+            }
+            .labelsHidden()
+            .controlSize(.small)
+        }
+        .frame(minHeight: 36)
+        .padding(.vertical, 4)
+        .disabled(isInactive)
+    }
+}
+
+// MARK: - Auto-mode warning
+
+/// Shown directly under the primary toggle when auto mode is armed but keep-awake
+/// isn't live right now, listing every safety check currently blocking it.
+private struct AutoDisabledWarning: View {
+    let reasons: [SafetyReason]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Image(systemName: "exclamationmark.circle.fill")
+                    .foregroundStyle(Color(nsColor: .systemYellow))
+                Text("Automatic mode is on, but keep-awake isn’t active right now.")
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .font(.callout)
+
+            Text("Temporarily disabled because the following check(s) failed:")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                ForEach(Array(reasons.enumerated()), id: \.offset) { _, reason in
+                    Text("• \(reason.checkLabel)")
+                        .font(.callout)
                         .foregroundStyle(.secondary)
-                        .monospacedDigit()
-                    Stepper("Low-battery cutoff", value: Binding(
-                        get: { state.settings.lowBatteryThreshold },
-                        set: { v in var s = state.settings; s.lowBatteryThreshold = v; state.updateSettings(s) }
-                    ), in: 5...50, step: 5)
-                    .labelsHidden()
-                    .controlSize(.small)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
+            }
+            .padding(.leading, 4)
+        }
+    }
+}
+
+// MARK: - Automatic
+
+private struct AutomaticSection: View {
+    @EnvironmentObject var state: AppState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Automatic")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .padding(.bottom, 2)
+
+            SettingRow(title: "Automatically enable when charging") {
+                Toggle("Automatically enable when charging", isOn: Binding(
+                    get: { state.settings.autoEnableWhenCharging },
+                    set: { v in var s = state.settings; s.autoEnableWhenCharging = v; state.updateSettings(s) }
+                ))
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .controlSize(.small)
             }
         }
     }

--- a/Sources/Lidless/MenuContent.swift
+++ b/Sources/Lidless/MenuContent.swift
@@ -247,16 +247,43 @@ private struct SafetySection: View {
     }
 }
 
-/// Full-width low-battery cutoff slider (0–100%, step 1). `0` means "Never" —
-/// the low-battery check is disabled entirely.
+/// Full-width low-battery cutoff slider (0–100%, snapping in 5% steps). `0` means
+/// "Never" — the low-battery check is disabled entirely.
 private struct LowBatteryCutoffRow: View {
     @EnvironmentObject var state: AppState
 
+    /// The value shown while dragging. Committing on every step would write
+    /// UserDefaults — and, in auto mode, run a reconcile that can reach the
+    /// privileged helper — once per 5% of travel, so the commit waits for the
+    /// drag to end.
+    @State private var dragging: Double?
+
     private var threshold: Int { state.settings.lowBatteryThreshold }
 
-    /// The cutoff is meaningless while "Only while charging" is on (keep-awake is
-    /// already blocked whenever off power), so the row is disabled/greyed then.
-    private var isInactive: Bool { state.settings.onlyWhileCharging }
+    /// The committed value, or the in-flight one while a drag is in progress.
+    private var shown: Int { Int((dragging ?? Double(threshold)).rounded()) }
+
+    /// The cutoff only ever fires off power, so it's meaningless whenever
+    /// keep-awake is already gated on being plugged in — under "Only while
+    /// charging", and equally under auto mode, which requires external power.
+    private var isInactive: Bool {
+        state.settings.onlyWhileCharging || state.settings.autoEnableWhenCharging
+    }
+
+    private var value: Binding<Double> {
+        Binding(get: { dragging ?? Double(threshold) },
+                set: { dragging = $0 })
+    }
+
+    /// Commit the dragged value once the drag ends, and only if it actually moved.
+    private func commit(editing: Bool) {
+        guard !editing, let value = dragging else { return }
+        dragging = nil
+        var updated = state.settings
+        updated.lowBatteryThreshold = Int(value.rounded())
+        guard updated != state.settings else { return }
+        state.updateSettings(updated)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -265,26 +292,19 @@ private struct LowBatteryCutoffRow: View {
                     .font(.callout)
                     .lineLimit(1)
                 Spacer(minLength: 16)
-                Text(threshold == 0 ? "Never" : "\(threshold)%")
+                Text(shown == 0 ? "Never" : "\(shown)%")
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .monospacedDigit()
             }
 
-            Slider(
-                value: Binding(
-                    get: { Double(threshold) },
-                    set: { v in var s = state.settings; s.lowBatteryThreshold = Int(v.rounded()); state.updateSettings(s) }
-                ),
-                in: 0...100,
-                step: 5
-            ) {
-                Text("Low-battery cutoff")
-            } minimumValueLabel: {
-                Text("Never").font(.caption2).foregroundStyle(.secondary)
-            } maximumValueLabel: {
-                Text("100%").font(.caption2).foregroundStyle(.secondary)
-            }
+            Slider(value: value,
+                   in: 0...100,
+                   step: 5,
+                   label: { Text("Low-battery cutoff") },
+                   minimumValueLabel: { Text("Never").font(.caption2).foregroundStyle(.secondary) },
+                   maximumValueLabel: { Text("100%").font(.caption2).foregroundStyle(.secondary) },
+                   onEditingChanged: commit)
             .labelsHidden()
             .controlSize(.small)
         }

--- a/Sources/Lidless/SettingsView.swift
+++ b/Sources/Lidless/SettingsView.swift
@@ -58,7 +58,16 @@ struct SettingsView: View {
                     LabeledContent("Turning off in", value: state.autoOffRemaining)
                         .foregroundStyle(.secondary)
                 }
+                // Auto mode decides activation on its own, so a countdown would
+                // disarm the feature out from under it. Say so rather than letting
+                // the picker look live while doing nothing.
+                if state.settings.autoEnableWhenCharging {
+                    Text("Not used while “Automatically enable when charging” is on.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
             }
+            .disabled(state.settings.autoEnableWhenCharging)
 
             Section("Updates") {
                 Toggle("Check for updates automatically", isOn: $updater.automaticallyChecksForUpdates)

--- a/Sources/Shared/AutoWriteCoordinator.swift
+++ b/Sources/Shared/AutoWriteCoordinator.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Tracks the one system write auto mode is allowed to have outstanding.
+///
+/// Auto mode writes from places that can fire while an earlier write is still
+/// resolving: the poll tick, and adopting a state observed from outside. On the
+/// privileged-helper path `setEnabled` only *dispatches* the write — the reply,
+/// the read-back, and any mismatch all land later, in a separate turn. A claim
+/// scoped to the call that issued the write is therefore worthless: it is
+/// already released by the time the reply arrives, so a write that reads back
+/// wrong immediately asks for another, recursing through the mismatch path and
+/// queueing XPC retries that supersede each other's callbacks.
+///
+/// So the claim spans the whole write — `issued` until `resolved` — and a
+/// resolution does *not* reopen writing in the same turn. Only `clear()` does,
+/// and every poll tick calls it, as does every reconcile the user just drove.
+/// Two properties fall out, and both are what make this safe to hold across an
+/// async boundary:
+///
+/// - A retry is never more than one tick away, so a resolution that defers is
+///   never a resolution that gives up.
+/// - A claim that never resolves cannot wedge the feature. A superseded helper
+///   reply is simply dropped — it never resolves anything — and the next tick
+///   clears the claim regardless.
+public struct AutoWriteCoordinator: Equatable {
+    public enum State: Equatable {
+        /// Nothing outstanding — auto mode may write.
+        case idle
+        /// A write was dispatched and hasn't resolved yet. On the helper path
+        /// this spans the XPC round trip and the read-back that follows it.
+        case inFlight(target: Bool)
+        /// A write resolved this turn, whatever its outcome. Another attempt
+        /// waits for the next tick rather than chasing the result immediately.
+        case deferred
+    }
+
+    public private(set) var state: State
+
+    public init(state: State = .idle) {
+        self.state = state
+    }
+
+    /// Whether auto mode may dispatch a write right now.
+    public var mayWrite: Bool { state == .idle }
+
+    /// The target of the write currently outstanding, if there is one.
+    public var inFlightTarget: Bool? {
+        guard case .inFlight(let target) = state else { return nil }
+        return target
+    }
+
+    /// Auto mode dispatched a write.
+    public mutating func issued(target: Bool) {
+        state = .inFlight(target: target)
+    }
+
+    /// The outstanding write reached a conclusion — confirmed, contradicted by
+    /// the read-back, unverifiable, or failed outright. All of them defer the
+    /// next attempt to the following tick; the distinction between them is the
+    /// caller's business, not this type's.
+    ///
+    /// Ignored unless a write is actually outstanding, so a late reply that lost
+    /// its claim to `clear()` can't retroactively defer a fresh one.
+    public mutating func resolved() {
+        guard case .inFlight = state else { return }
+        state = .deferred
+    }
+
+    /// Drop any claim and allow a write immediately. Called at the top of every
+    /// poll tick, by the reconcile paths the user just drove (where waiting a
+    /// tick would read as broken), and when a write from another origin takes
+    /// over — that write owns the flag now, and auto mode's pending reply, if one
+    /// is still in flight, will be rejected as superseded.
+    public mutating func clear() {
+        state = .idle
+    }
+}

--- a/Sources/Shared/AutoWriteCoordinator.swift
+++ b/Sources/Shared/AutoWriteCoordinator.swift
@@ -12,16 +12,32 @@ import Foundation
 /// queueing XPC retries that supersede each other's callbacks.
 ///
 /// So the claim spans the whole write — `issued` until `resolved` — and a
-/// resolution does *not* reopen writing in the same turn. Only `clear()` does,
-/// and every poll tick calls it, as does every reconcile the user just drove.
-/// Two properties fall out, and both are what make this safe to hold across an
+/// resolution does *not* reopen writing in the same turn.
+///
+/// Recovery is a poll tick, but a tick cannot simply drop the claim: it carries
+/// no evidence that the request it would drop is finished. A tick landing a
+/// moment after a dispatch would otherwise send a second write while the first
+/// is still alive. So `advanceTick()` retires a claim over *two* ticks — an
+/// outstanding write loses this tick's attempt and only reopens on the next one
+/// — which gives the two properties that make a claim safe to hold across an
 /// async boundary:
 ///
-/// - A retry is never more than one tick away, so a resolution that defers is
-///   never a resolution that gives up.
-/// - A claim that never resolves cannot wedge the feature. A superseded helper
-///   reply is simply dropped — it never resolves anything — and the next tick
-///   clears the claim regardless.
+/// - A concluded write always gets another attempt, one tick later.
+/// - A claim that never concludes cannot wedge the feature: worst case two ticks
+///   pass and writing reopens on the assumption the reply was lost.
+///
+/// That second property is only safe because the reply is bounded. The helper
+/// call resolves within its own timeout whether or not the daemon answers — the
+/// deadline is armed unconditionally alongside the request — and that bound is
+/// several times shorter than the poll interval. So by the tick that demotes a
+/// claim, its callback has already run; reopening a tick after *that* cannot
+/// dispatch alongside a pending one. (The timeout settles the callback, not the
+/// message: a daemon that eventually processes a timed-out request is the
+/// existing failure path's problem, and writing the flag is idempotent.)
+///
+/// `clear()` is the deliberate exception, for when something genuinely takes the
+/// flag away from auto mode — a user-driven reconcile, or a write from another
+/// origin. Those supersede the outstanding reply rather than racing it.
 public struct AutoWriteCoordinator: Equatable {
     public enum State: Equatable {
         /// Nothing outstanding — auto mode may write.
@@ -60,17 +76,40 @@ public struct AutoWriteCoordinator: Equatable {
     /// caller's business, not this type's.
     ///
     /// Ignored unless a write is actually outstanding, so a late reply that lost
-    /// its claim to `clear()` can't retroactively defer a fresh one.
+    /// its claim — to `clear()`, or to a tick that already demoted it — can't
+    /// retroactively defer a fresh claim or reopen a deferral early.
     public mutating func resolved() {
         guard case .inFlight = state else { return }
         state = .deferred
     }
 
-    /// Drop any claim and allow a write immediately. Called at the top of every
-    /// poll tick, by the reconcile paths the user just drove (where waiting a
-    /// tick would read as broken), and when a write from another origin takes
-    /// over — that write owns the flag now, and auto mode's pending reply, if one
-    /// is still in flight, will be rejected as superseded.
+    /// A new poll tick began.
+    ///
+    /// A concluded write reopens here — that is the retry. An *outstanding* one
+    /// does not: the tick boundary says nothing about whether the request is
+    /// finished, and reopening on it would dispatch a second write alongside a
+    /// live first. It is demoted instead, so it forfeits this tick's attempt and
+    /// reopens on the next — the point by which a reply that was coming would
+    /// have come, and a lost one can be written off.
+    public mutating func advanceTick() {
+        switch state {
+        case .idle:
+            break
+        case .inFlight:
+            state = .deferred
+        case .deferred:
+            state = .idle
+        }
+    }
+
+    /// Drop any claim and allow a write immediately, superseding whatever is
+    /// outstanding. Only for the paths that genuinely take the flag away from
+    /// auto mode: a reconcile the user just drove, and a write from another
+    /// origin. In both cases auto mode's pending reply, if one is still in
+    /// flight, is rejected as superseded rather than raced.
+    ///
+    /// Not for the poll tick — see `advanceTick()`, which exists because a tick
+    /// has no such authority over a live request.
     public mutating func clear() {
         state = .idle
     }

--- a/Sources/Shared/SafetySettings.swift
+++ b/Sources/Shared/SafetySettings.swift
@@ -5,17 +5,25 @@ public struct SafetySettings: Equatable {
     public var lowBatteryThreshold: Int
     public var onlyWhileCharging: Bool
     public var pauseOnHighThermal: Bool
+    /// When true, keep-awake automatically (re-)activates while the Mac is on
+    /// external power and every enabled safety check passes. See `AutoEnablePolicy`.
+    public var autoEnableWhenCharging: Bool
 
     public static let `default` = SafetySettings(
         lowBatteryThreshold: 20,
         onlyWhileCharging: false,
-        pauseOnHighThermal: true
+        pauseOnHighThermal: true,
+        autoEnableWhenCharging: false
     )
 
-    public init(lowBatteryThreshold: Int, onlyWhileCharging: Bool, pauseOnHighThermal: Bool) {
+    public init(lowBatteryThreshold: Int,
+                onlyWhileCharging: Bool,
+                pauseOnHighThermal: Bool,
+                autoEnableWhenCharging: Bool = false) {
         self.lowBatteryThreshold = lowBatteryThreshold
         self.onlyWhileCharging = onlyWhileCharging
         self.pauseOnHighThermal = pauseOnHighThermal
+        self.autoEnableWhenCharging = autoEnableWhenCharging
     }
 }
 
@@ -24,12 +32,16 @@ public enum SafetyReason: Equatable {
     case highThermal
     case notCharging
     case lowBattery(Int)
+    /// The Mac isn't on external power. Used by auto-enable mode, which requires
+    /// external power regardless of the "Only while charging" preference.
+    case notOnPower
 
     public var message: String {
         switch self {
         case .highThermal:        return "Auto-paused: the Mac is running hot."
         case .notCharging:        return "Auto-paused: not on charger."
         case .lowBattery(let p):  return "Auto-paused: battery \(p)% on battery power."
+        case .notOnPower:         return "Auto-paused: not connected to power."
         }
     }
 
@@ -40,6 +52,18 @@ public enum SafetyReason: Equatable {
         case .highThermal:        return "Your Mac is running hot, so keep-awake is paused. It'll be available again once the Mac cools down."
         case .notCharging:        return "\u{201C}Only while charging\u{201D} is on, so connect your Mac to power to keep it awake."
         case .lowBattery(let p):  return "Battery is at \(p)%. Charge above the low-battery cutoff to keep your Mac awake."
+        case .notOnPower:         return "Connect your Mac to power to keep it awake."
+        }
+    }
+
+    /// Short phrasing for the auto-mode warning bullet list (e.g. "Not connected
+    /// to power"). Reflects the *current* unmet condition, not an auto-pause event.
+    public var checkLabel: String {
+        switch self {
+        case .highThermal:        return "Running hot"
+        case .notCharging:        return "Not on charger"
+        case .lowBattery(let p):  return "Battery \(p)% is at or below the cutoff"
+        case .notOnPower:         return "Not connected to power"
         }
     }
 }
@@ -49,6 +73,9 @@ public enum SafetyEvaluator {
     /// The reason keep-awake should be disabled given current conditions, or
     /// `nil` if it's safe to stay awake. Checked in priority order:
     /// thermal first (hardware protection), then charging policy, then battery.
+    ///
+    /// A `lowBatteryThreshold` of 0 means "Never" — the low-battery check is
+    /// disabled entirely.
     public static func reasonToDisable(battery: BatteryInfo,
                                        thermalSerious: Bool,
                                        settings: SafetySettings) -> SafetyReason? {
@@ -58,9 +85,52 @@ public enum SafetyEvaluator {
         if settings.onlyWhileCharging && !battery.onAC {
             return .notCharging
         }
-        if !battery.onAC && battery.percent <= settings.lowBatteryThreshold {
+        if settings.lowBatteryThreshold > 0
+            && !battery.onAC
+            && battery.percent <= settings.lowBatteryThreshold {
             return .lowBattery(battery.percent)
         }
         return nil
+    }
+
+    /// Every currently-unmet check, for the auto-mode warning list — unlike
+    /// `reasonToDisable`, which stops at the first. `requirePower` adds the
+    /// external-power requirement that auto mode imposes on top of the user's
+    /// enabled safety checks; when off power that power bullet subsumes the
+    /// redundant "Only while charging" one so we never list both.
+    public static func allUnmetReasons(battery: BatteryInfo,
+                                       thermalSerious: Bool,
+                                       settings: SafetySettings,
+                                       requirePower: Bool) -> [SafetyReason] {
+        var reasons: [SafetyReason] = []
+        if settings.pauseOnHighThermal && thermalSerious {
+            reasons.append(.highThermal)
+        }
+        if requirePower && !battery.onAC {
+            reasons.append(.notOnPower)
+        } else if settings.onlyWhileCharging && !battery.onAC {
+            reasons.append(.notCharging)
+        }
+        if settings.lowBatteryThreshold > 0
+            && !battery.onAC
+            && battery.percent <= settings.lowBatteryThreshold {
+            reasons.append(.lowBattery(battery.percent))
+        }
+        return reasons
+    }
+}
+
+/// Pure decision for auto-enable mode ("Automatically enable when charging").
+/// Keep-awake may activate only while on external power *and* every enabled
+/// safety check passes. Requiring external power makes the low-battery check
+/// moot (it only fires off power), matching "ignore the battery check on power".
+public enum AutoEnablePolicy {
+    public static func canActivate(battery: BatteryInfo,
+                                   thermalSerious: Bool,
+                                   settings: SafetySettings) -> Bool {
+        guard battery.onAC else { return false }
+        return SafetyEvaluator.reasonToDisable(battery: battery,
+                                               thermalSerious: thermalSerious,
+                                               settings: settings) == nil
     }
 }

--- a/Sources/Shared/SafetySettings.swift
+++ b/Sources/Shared/SafetySettings.swift
@@ -85,12 +85,18 @@ public enum SafetyEvaluator {
         if settings.onlyWhileCharging && !battery.onAC {
             return .notCharging
         }
-        if settings.lowBatteryThreshold > 0
-            && !battery.onAC
-            && battery.percent <= settings.lowBatteryThreshold {
-            return .lowBattery(battery.percent)
-        }
-        return nil
+        return lowBatteryReason(battery: battery, settings: settings)
+    }
+
+    /// The low-battery check, shared by `reasonToDisable` and `allUnmetReasons`
+    /// so the two can't drift. Only fires off power, and a threshold of 0
+    /// ("Never") disables it entirely.
+    private static func lowBatteryReason(battery: BatteryInfo,
+                                         settings: SafetySettings) -> SafetyReason? {
+        guard settings.lowBatteryThreshold > 0,
+              !battery.onAC,
+              battery.percent <= settings.lowBatteryThreshold else { return nil }
+        return .lowBattery(battery.percent)
     }
 
     /// Every currently-unmet check, for the auto-mode warning list — unlike
@@ -111,10 +117,8 @@ public enum SafetyEvaluator {
         } else if settings.onlyWhileCharging && !battery.onAC {
             reasons.append(.notCharging)
         }
-        if settings.lowBatteryThreshold > 0
-            && !battery.onAC
-            && battery.percent <= settings.lowBatteryThreshold {
-            reasons.append(.lowBattery(battery.percent))
+        if let lowBattery = lowBatteryReason(battery: battery, settings: settings) {
+            reasons.append(lowBattery)
         }
         return reasons
     }
@@ -132,5 +136,21 @@ public enum AutoEnablePolicy {
         return SafetyEvaluator.reasonToDisable(battery: battery,
                                                thermalSerious: thermalSerious,
                                                settings: settings) == nil
+    }
+
+    /// The live keep-awake state auto mode wants, or `nil` when there's nothing
+    /// to do — auto mode is off, or the live state already matches. Returning
+    /// `nil` for "already correct" keeps the caller from writing the system flag
+    /// on every poll tick.
+    public static func target(armed: Bool,
+                              currentlyEnabled: Bool,
+                              battery: BatteryInfo,
+                              thermalSerious: Bool,
+                              settings: SafetySettings) -> Bool? {
+        guard settings.autoEnableWhenCharging else { return nil }
+        let shouldBeOn = armed && canActivate(battery: battery,
+                                              thermalSerious: thermalSerious,
+                                              settings: settings)
+        return shouldBeOn == currentlyEnabled ? nil : shouldBeOn
     }
 }

--- a/Sources/Shared/SafetySettings.swift
+++ b/Sources/Shared/SafetySettings.swift
@@ -68,6 +68,23 @@ public enum SafetyReason: Equatable {
     }
 }
 
+/// One sample of everything a safety decision reads from the world.
+///
+/// Exists so a decision and the write it authorises can be judged against the
+/// same conditions. Sampling twice — once to decide, once to check on the way
+/// out — puts a seam between them that the world can change across, and a write
+/// refused at that seam is a write that never claimed a mutation, so it
+/// supersedes nothing and leaves whatever it was correcting in force.
+public struct SafetySnapshot: Equatable {
+    public let battery: BatteryInfo
+    public let thermalSerious: Bool
+
+    public init(battery: BatteryInfo, thermalSerious: Bool) {
+        self.battery = battery
+        self.thermalSerious = thermalSerious
+    }
+}
+
 /// Pure safety decision. No side effects, fully unit-testable.
 public enum SafetyEvaluator {
     /// The reason keep-awake should be disabled given current conditions, or
@@ -181,12 +198,30 @@ public enum AutoEnablePolicy {
     /// which would leave the superseded auto reply free to land after all; a
     /// write of `false` is never refused.
     public static func handoffToManual(pendingTarget: Bool,
-                                       battery: BatteryInfo,
-                                       thermalSerious: Bool,
+                                       conditions: SafetySnapshot,
                                        settings: SafetySettings) -> Bool {
         guard pendingTarget else { return false }
-        return SafetyEvaluator.reasonToDisable(battery: battery,
-                                               thermalSerious: thermalSerious,
+        return writeIsPermitted(target: true, conditions: conditions, settings: settings)
+    }
+
+    /// Whether the safety check on the way out of `setEnabled` will let a write
+    /// of `target` through, given the conditions it checks against.
+    ///
+    /// This mirrors that check exactly, so a caller can guarantee its write won't
+    /// be refused by handing the same snapshot to both. Two properties follow,
+    /// and the auto path depends on each:
+    ///
+    /// - A `false` target is never refused. That is what lets a corrective "off"
+    ///   supersede a pending "on" under any conditions at all.
+    /// - A `true` target decided from a snapshot is still permitted under that
+    ///   same snapshot, by construction. Re-sampling instead would reopen the
+    ///   seam this is here to close.
+    public static func writeIsPermitted(target: Bool,
+                                        conditions: SafetySnapshot,
+                                        settings: SafetySettings) -> Bool {
+        guard target else { return true }
+        return SafetyEvaluator.reasonToDisable(battery: conditions.battery,
+                                               thermalSerious: conditions.thermalSerious,
                                                settings: settings) == nil
     }
 }

--- a/Sources/Shared/SafetySettings.swift
+++ b/Sources/Shared/SafetySettings.swift
@@ -139,9 +139,13 @@ public enum AutoEnablePolicy {
     }
 
     /// The live keep-awake state auto mode wants, or `nil` when there's nothing
-    /// to do — auto mode is off, or the live state already matches. Returning
-    /// `nil` for "already correct" keeps the caller from writing the system flag
-    /// on every poll tick.
+    /// to do — auto mode is off, or the state already matches. Returning `nil`
+    /// for "already correct" keeps the caller from writing the system flag on
+    /// every poll tick.
+    ///
+    /// `currentlyEnabled` must be the *effective* state — see `effectiveState`.
+    /// Comparing against the shown state instead is how an intent expressed
+    /// while a write is still travelling gets silently dropped.
     public static func target(armed: Bool,
                               currentlyEnabled: Bool,
                               battery: BatteryInfo,
@@ -152,5 +156,37 @@ public enum AutoEnablePolicy {
                                               thermalSerious: thermalSerious,
                                               settings: settings)
         return shouldBeOn == currentlyEnabled ? nil : shouldBeOn
+    }
+
+    /// Where keep-awake is *heading*: the target of a write still in flight, or
+    /// the shown state when nothing is outstanding.
+    ///
+    /// Every decision has to be taken against this rather than against the shown
+    /// state. A dispatched write hasn't moved `isEnabled` yet — that happens in
+    /// its reply — so a user changing their mind mid-flight would otherwise be
+    /// compared against a state the system has already left, conclude nothing
+    /// needs doing, and let the earlier write land unopposed.
+    public static func effectiveState(pendingTarget: Bool?, live: Bool) -> Bool {
+        pendingTarget ?? live
+    }
+
+    /// Leaving auto mode while a write is still travelling: the state to settle
+    /// on, which the caller must then actually write.
+    ///
+    /// Manual mode inherits where the system was heading, so the starting point
+    /// is the outstanding target. But "on" is only honest while it's still
+    /// allowed — conditions can have lapsed since that write went out — and
+    /// settling on "off" is also what keeps the write unconditional. A write of
+    /// `true` can be refused by the safety check before it claims a mutation,
+    /// which would leave the superseded auto reply free to land after all; a
+    /// write of `false` is never refused.
+    public static func handoffToManual(pendingTarget: Bool,
+                                       battery: BatteryInfo,
+                                       thermalSerious: Bool,
+                                       settings: SafetySettings) -> Bool {
+        guard pendingTarget else { return false }
+        return SafetyEvaluator.reasonToDisable(battery: battery,
+                                               thermalSerious: thermalSerious,
+                                               settings: settings) == nil
     }
 }

--- a/Sources/Shared/SettingsStore.swift
+++ b/Sources/Shared/SettingsStore.swift
@@ -9,6 +9,8 @@ public struct SettingsStore {
         static let lowBattery   = "lowBatteryThreshold"
         static let onlyCharging = "onlyWhileCharging"
         static let pauseThermal = "pauseOnHighThermal"
+        static let autoEnable   = "autoEnableWhenCharging"
+        static let armed        = "keepAwakeArmed"
         static let seeded       = "settingsSeeded"
         static let autoOff      = "autoOffMinutes"
         static let onboarded    = "onboardingComplete"
@@ -25,7 +27,8 @@ public struct SettingsStore {
         return SafetySettings(
             lowBatteryThreshold: defaults.integer(forKey: Key.lowBattery),
             onlyWhileCharging: defaults.bool(forKey: Key.onlyCharging),
-            pauseOnHighThermal: defaults.bool(forKey: Key.pauseThermal)
+            pauseOnHighThermal: defaults.bool(forKey: Key.pauseThermal),
+            autoEnableWhenCharging: defaults.bool(forKey: Key.autoEnable)
         )
     }
 
@@ -33,7 +36,18 @@ public struct SettingsStore {
         defaults.set(settings.lowBatteryThreshold, forKey: Key.lowBattery)
         defaults.set(settings.onlyWhileCharging, forKey: Key.onlyCharging)
         defaults.set(settings.pauseOnHighThermal, forKey: Key.pauseThermal)
+        defaults.set(settings.autoEnableWhenCharging, forKey: Key.autoEnable)
         defaults.set(true, forKey: Key.seeded)
+    }
+
+    /// The master-toggle intent in auto mode: whether the user wants keep-awake
+    /// armed (the live state is then gated by power + safety). Defaults to false.
+    public func loadArmed() -> Bool {
+        defaults.bool(forKey: Key.armed)
+    }
+
+    public func saveArmed(_ armed: Bool) {
+        defaults.set(armed, forKey: Key.armed)
     }
 
     /// Auto-off duration in minutes (`0` = no auto-off). Defaults to 0.

--- a/Sources/Shared/StateReconciler.swift
+++ b/Sources/Shared/StateReconciler.swift
@@ -27,6 +27,11 @@ public enum SetOrigin: Equatable {
     case safety
     /// The auto-off timer elapsed.
     case autoOff
+    /// Auto-enable mode deriving the live state from the armed intent. Distinct
+    /// from `.safety` because this origin can turn keep-awake *on* as well as
+    /// off, and it fires unprompted on the poll timer — so it must never present
+    /// an alert or disturb a notice the user hasn't seen yet.
+    case auto
 }
 
 /// A write whose read-back hasn't confirmed it yet.

--- a/Sources/Shared/StateReconciler.swift
+++ b/Sources/Shared/StateReconciler.swift
@@ -27,10 +27,11 @@ public enum SetOrigin: Equatable {
     case safety
     /// The auto-off timer elapsed.
     case autoOff
-    /// Auto-enable mode deriving the live state from the armed intent. Distinct
-    /// from `.safety` because this origin can turn keep-awake *on* as well as
-    /// off, and it fires unprompted on the poll timer — so it must never present
-    /// an alert or disturb a notice the user hasn't seen yet.
+    /// Auto-enable mode deriving the live state from the armed intent — including
+    /// the write that settles its last outstanding one as the user leaves the
+    /// mode. Distinct from `.safety` because this origin can turn keep-awake *on*
+    /// as well as off, and it isn't the user acting on the switch — so it must
+    /// never present an alert or disturb a notice they haven't seen yet.
     case auto
 }
 

--- a/Tests/LidlessTests/AutoPendingWriteTests.swift
+++ b/Tests/LidlessTests/AutoPendingWriteTests.swift
@@ -57,8 +57,8 @@ final class AutoPendingWriteTests: XCTestCase {
     /// auto reply, so the state can't move afterwards in a mode that's gone.
     func testDisablingAutoModeSettlesOnThePendingTarget() {
         XCTAssertTrue(AutoEnablePolicy.handoffToManual(
-            pendingTarget: true, battery: onPower,
-            thermalSerious: false, settings: auto))
+            pendingTarget: true, conditions: SafetySnapshot(battery: onPower, thermalSerious: false),
+            settings: auto))
     }
 
     /// Inheriting "on" is only honest while it's still allowed. Unplugged with a
@@ -69,19 +69,19 @@ final class AutoPendingWriteTests: XCTestCase {
         var s = auto
         s.lowBatteryThreshold = 90                          // 80% is at/below it
         XCTAssertFalse(AutoEnablePolicy.handoffToManual(
-            pendingTarget: true, battery: offPower,
-            thermalSerious: false, settings: s))
+            pendingTarget: true, conditions: SafetySnapshot(battery: offPower, thermalSerious: false),
+            settings: s))
 
         XCTAssertFalse(AutoEnablePolicy.handoffToManual(
-            pendingTarget: true, battery: onPower,
-            thermalSerious: true, settings: auto), "running hot blocks the inheritance too")
+            pendingTarget: true, conditions: SafetySnapshot(battery: onPower, thermalSerious: true),
+            settings: auto), "running hot blocks the inheritance too")
     }
 
     /// A pending "off" settles off, and never trips the refusal path.
     func testDisablingAutoModeDuringAPendingOffSettlesOff() {
         XCTAssertFalse(AutoEnablePolicy.handoffToManual(
-            pendingTarget: false, battery: onPower,
-            thermalSerious: false, settings: auto))
+            pendingTarget: false, conditions: SafetySnapshot(battery: onPower, thermalSerious: false),
+            settings: auto))
     }
 
     // MARK: 3 — pending ON + a change that still wants ON ⇒ no duplicate
@@ -138,5 +138,103 @@ final class AutoPendingWriteTests: XCTestCase {
 
         // …time passes, the stale reply finally arrives…
         XCTAssertFalse(sync.shouldApply(stale))
+    }
+
+    // MARK: 5 — the decision/write seam
+
+    /// Conditions moving between deciding and writing is what the snapshot is
+    /// for. Decided while plugged in, the "on" write is permitted; re-sampled a
+    /// moment later on battery below the cutoff, the very same write is refused —
+    /// and a refusal claims no mutation, so it supersedes nothing.
+    func testResamplingAcrossTheSeamWouldRefuseAWriteTheDecisionAllowed() {
+        var s = auto
+        s.lowBatteryThreshold = 90
+
+        let decided = SafetySnapshot(battery: onPower, thermalSerious: false)
+        XCTAssertTrue(AutoEnablePolicy.writeIsPermitted(target: true, conditions: decided, settings: s),
+                      "the decision was taken on power, where 'on' is allowed")
+
+        let resampled = SafetySnapshot(battery: offPower, thermalSerious: false)
+        XCTAssertFalse(AutoEnablePolicy.writeIsPermitted(target: true, conditions: resampled, settings: s),
+                       "re-reading a moment later can refuse the write the decision authorised")
+    }
+
+    /// So the write is checked against the snapshot it was decided from, which
+    /// makes "decided allowed ⇒ not refused" hold by construction.
+    func testAWriteDecidedFromASnapshotIsPermittedUnderThatSnapshot() {
+        var decisions = 0
+        for onAC in [true, false] {
+            for percent in [0, 15, 50, 100] {
+                for hot in [true, false] {
+                    for threshold in [0, 20, 90] {
+                        var s = auto
+                        s.lowBatteryThreshold = threshold
+                        let conditions = SafetySnapshot(
+                            battery: BatteryInfo(percent: percent, onAC: onAC),
+                            thermalSerious: hot)
+
+                        guard let target = AutoEnablePolicy.target(
+                            armed: true, currentlyEnabled: false,
+                            battery: conditions.battery,
+                            thermalSerious: conditions.thermalSerious,
+                            settings: s) else { continue }
+
+                        decisions += 1
+                        XCTAssertTrue(
+                            AutoEnablePolicy.writeIsPermitted(target: target,
+                                                              conditions: conditions,
+                                                              settings: s),
+                            "decided \(target) from \(conditions) but the write would be refused")
+                    }
+                }
+            }
+        }
+        XCTAssertGreaterThan(decisions, 0, "the `continue` must not have skipped every case")
+    }
+
+    /// The same guarantee for the handoff, which is where a refusal would be
+    /// worst: it settles the mode transition, so a write that never claims a
+    /// mutation leaves the auto reply free to land afterwards.
+    func testEveryHandoffDecisionYieldsAPermittedWrite() {
+        for pending in [true, false] {
+            for onAC in [true, false] {
+                for hot in [true, false] {
+                    for threshold in [0, 20, 90] {
+                        var s = auto
+                        s.lowBatteryThreshold = threshold
+                        let conditions = SafetySnapshot(
+                            battery: BatteryInfo(percent: 15, onAC: onAC),
+                            thermalSerious: hot)
+
+                        let settled = AutoEnablePolicy.handoffToManual(
+                            pendingTarget: pending, conditions: conditions, settings: s)
+
+                        XCTAssertTrue(
+                            AutoEnablePolicy.writeIsPermitted(target: settled,
+                                                              conditions: conditions,
+                                                              settings: s),
+                            "handoff settled on \(settled) from \(conditions) but would be refused")
+                    }
+                }
+            }
+        }
+    }
+
+    /// And the property the corrective "off" leans on, stated on its own: an
+    /// "off" write is permitted under any conditions whatsoever, so it can always
+    /// claim its mutation and supersede a pending "on".
+    func testAnOffWriteIsNeverRefused() {
+        for onAC in [true, false] {
+            for hot in [true, false] {
+                for threshold in [0, 50] {
+                    var s = auto
+                    s.lowBatteryThreshold = threshold
+                    let conditions = SafetySnapshot(
+                        battery: BatteryInfo(percent: 5, onAC: onAC), thermalSerious: hot)
+                    XCTAssertTrue(AutoEnablePolicy.writeIsPermitted(
+                        target: false, conditions: conditions, settings: s))
+                }
+            }
+        }
     }
 }

--- a/Tests/LidlessTests/AutoPendingWriteTests.swift
+++ b/Tests/LidlessTests/AutoPendingWriteTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+
+/// Decisions taken while an auto-mode write is still travelling.
+///
+/// A dispatched write hasn't moved `isEnabled` yet — that happens in its reply —
+/// so anything deciding against the shown state during that window is comparing
+/// against a state the system has already left. These pin the four sequences
+/// where that distinction decides the outcome.
+final class AutoPendingWriteTests: XCTestCase {
+
+    private var auto: SafetySettings {
+        var s = SafetySettings.default
+        s.autoEnableWhenCharging = true
+        return s
+    }
+
+    private let onPower = BatteryInfo(percent: 80, onAC: true)
+    private let offPower = BatteryInfo(percent: 80, onAC: false)
+
+    /// Where the system is heading, which is what every decision compares to.
+    private func effective(pending: Bool?, live: Bool) -> Bool {
+        AutoEnablePolicy.effectiveState(pendingTarget: pending, live: live)
+    }
+
+    // MARK: 1 — pending ON + disarm ⇒ corrective OFF
+
+    /// The user flips the master toggle off while the "on" write is in flight.
+    /// Against the shown state this reads as "already off, nothing to do", and
+    /// the earlier write then lands and turns keep-awake on moments after they
+    /// turned it off. Against the effective state it yields a corrective write.
+    func testDisarmingDuringAPendingOnWriteIssuesACorrectiveOff() {
+        let live = false                        // the reply hasn't landed yet
+        let pending: Bool? = true
+
+        XCTAssertTrue(effective(pending: pending, live: live))
+
+        let corrective = AutoEnablePolicy.target(
+            armed: false,
+            currentlyEnabled: effective(pending: pending, live: live),
+            battery: onPower, thermalSerious: false, settings: auto)
+        XCTAssertEqual(corrective, false, "disarming mid-flight must issue a corrective off")
+    }
+
+    /// The same inputs judged against the shown state instead — the bug this
+    /// guards, kept explicit so the distinction can't quietly regress.
+    func testDecidingAgainstTheShownStateWouldDropTheDisarm() {
+        let dropped = AutoEnablePolicy.target(
+            armed: false, currentlyEnabled: false,           // shown, not effective
+            battery: onPower, thermalSerious: false, settings: auto)
+        XCTAssertNil(dropped, "this is precisely why the decision can't use the shown state")
+    }
+
+    // MARK: 2 — pending ON + auto mode disabled ⇒ settled now, not late
+
+    /// Leaving auto mode settles on where the system was heading, decided at the
+    /// transition. The point is that a write is issued at all: it supersedes the
+    /// auto reply, so the state can't move afterwards in a mode that's gone.
+    func testDisablingAutoModeSettlesOnThePendingTarget() {
+        XCTAssertTrue(AutoEnablePolicy.handoffToManual(
+            pendingTarget: true, battery: onPower,
+            thermalSerious: false, settings: auto))
+    }
+
+    /// Inheriting "on" is only honest while it's still allowed. Unplugged with a
+    /// cutoff in reach, the settle is "off" — which is also what keeps the write
+    /// unconditional: `setEnabled(true)` can be refused by the safety check
+    /// *before* it claims a mutation, and a refused write supersedes nothing.
+    func testDisablingAutoModeSettlesOffWhenTheTargetIsNoLongerAllowed() {
+        var s = auto
+        s.lowBatteryThreshold = 90                          // 80% is at/below it
+        XCTAssertFalse(AutoEnablePolicy.handoffToManual(
+            pendingTarget: true, battery: offPower,
+            thermalSerious: false, settings: s))
+
+        XCTAssertFalse(AutoEnablePolicy.handoffToManual(
+            pendingTarget: true, battery: onPower,
+            thermalSerious: true, settings: auto), "running hot blocks the inheritance too")
+    }
+
+    /// A pending "off" settles off, and never trips the refusal path.
+    func testDisablingAutoModeDuringAPendingOffSettlesOff() {
+        XCTAssertFalse(AutoEnablePolicy.handoffToManual(
+            pendingTarget: false, battery: onPower,
+            thermalSerious: false, settings: auto))
+    }
+
+    // MARK: 3 — pending ON + a change that still wants ON ⇒ no duplicate
+
+    /// Toggling something the decision doesn't depend on, while the "on" write is
+    /// still travelling. The new intent agrees with what's already on its way, so
+    /// there must be no second write.
+    func testASettingsChangeThatStillWantsOnIssuesNoDuplicateWrite() {
+        var s = auto
+        s.pauseOnHighThermal = false            // irrelevant while cool and on power
+
+        XCTAssertNil(AutoEnablePolicy.target(
+            armed: true,
+            currentlyEnabled: effective(pending: true, live: false),
+            battery: onPower, thermalSerious: false, settings: s),
+            "the write already on its way is heading where we want it")
+    }
+
+    /// And the claim on that write must survive the decision. Clearing it would
+    /// lose the pending target and let the next tick dispatch a duplicate
+    /// alongside a request that is still live.
+    func testTheClaimSurvivesADecisionThatChangesNothing() {
+        var c = AutoWriteCoordinator()
+        c.issued(target: true)
+
+        // A user-driven reconcile that concludes `nil` touches nothing.
+        XCTAssertEqual(c.state, .inFlight(target: true))
+        XCTAssertEqual(c.inFlightTarget, true, "the pending target must remain readable")
+        XCTAssertFalse(c.mayWrite, "and the poll must still be locked out")
+    }
+
+    // MARK: 4 — a late reply cannot overwrite the corrective write
+
+    /// The corrective write claims a new mutation, which is what strips the
+    /// superseded reply of its authority. Without a write being issued at all —
+    /// the `nil` decision in test 2 — there is no `beginMutation`, and the old
+    /// reply stays valid: that is the whole failure.
+    func testCorrectiveWriteSupersedesTheEarlierReply() {
+        var sync = StateSync()
+        let auto = sync.beginMutation()                     // the "on" write
+        XCTAssertTrue(sync.shouldApply(auto))
+
+        let corrective = sync.beginMutation()               // the corrective "off"
+        XCTAssertFalse(sync.shouldApply(auto), "the late auto reply must be rejected")
+        XCTAssertTrue(sync.shouldApply(corrective))
+    }
+
+    /// Ordering is the other half: the reply can arrive after the corrective
+    /// write was issued, and must still lose.
+    func testLateReplyLosesRegardlessOfArrivalOrder() {
+        var sync = StateSync()
+        let stale = sync.beginMutation()
+        sync.beginMutation()
+
+        // …time passes, the stale reply finally arrives…
+        XCTAssertFalse(sync.shouldApply(stale))
+    }
+}

--- a/Tests/LidlessTests/AutoWriteCoordinatorTests.swift
+++ b/Tests/LidlessTests/AutoWriteCoordinatorTests.swift
@@ -59,13 +59,70 @@ final class AutoWriteCoordinatorTests: XCTestCase {
     }
 
     /// A late reply that lost its claim to `clear()` must not retroactively
-    /// defer the tick that replaced it.
+    /// defer the fresh claim that replaced it.
     func testResolutionWithoutAClaimIsIgnored() {
         var c = AutoWriteCoordinator()
         c.issued(target: true)
-        c.clear()                               // next tick took over
+        c.clear()                               // a user write took over
         c.resolved()                            // superseded reply, arriving late
-        XCTAssertTrue(c.mayWrite, "a stale reply must not close a fresh tick's door")
+        XCTAssertTrue(c.mayWrite, "a stale reply must not close a fresh claim's door")
+    }
+
+    // MARK: A tick must not race a live request
+
+    /// The tick timer is indifferent to when the write was dispatched: it can
+    /// land 100ms after one. The helper's own 6s timeout is no help at that
+    /// distance, so the tick must not reopen writing on a claim that may still
+    /// have a live request behind it.
+    func testTickImmediatelyAfterIssueBlocksASecondWrite() {
+        var c = AutoWriteCoordinator()
+        c.issued(target: true)
+
+        c.advanceTick()                         // timer fires moments after dispatch
+        XCTAssertFalse(c.mayWrite, "a tick must not dispatch alongside a live request")
+    }
+
+    /// A reply that never arrives is written off — but only after the write has
+    /// forfeited a tick, by which point the helper's timeout has long since
+    /// fired and there is no live request left to duplicate.
+    func testLostInFlightRecoversOnlyOnTheFollowingTick() {
+        var c = AutoWriteCoordinator()
+        c.issued(target: true)
+
+        c.advanceTick()
+        XCTAssertFalse(c.mayWrite, "first tick forfeits the attempt, it doesn't reopen")
+        XCTAssertEqual(c.state, .deferred)
+
+        c.advanceTick()
+        XCTAssertTrue(c.mayWrite, "the following tick writes the lost reply off")
+    }
+
+    /// A tick demoting a live claim, then that claim's reply finally landing,
+    /// must neither reopen writing early nor re-close what the next tick opens.
+    func testLateResolutionAfterATickTransitionSettlesCorrectly() {
+        var c = AutoWriteCoordinator()
+        c.issued(target: true)
+        c.advanceTick()                         // demoted while still live
+
+        c.resolved()                            // the reply, arriving afterwards
+        XCTAssertEqual(c.state, .deferred, "a late reply must not reopen writing early")
+        XCTAssertFalse(c.mayWrite)
+
+        c.advanceTick()
+        XCTAssertTrue(c.mayWrite, "and must not cost the claim its retry either")
+    }
+
+    /// The mirror case: resolved *before* the tick, so the tick is the retry.
+    /// A second, later reply must not re-close it.
+    func testLateResolutionAfterAReopeningTickDoesNotReclose() {
+        var c = AutoWriteCoordinator()
+        c.issued(target: true)
+        c.resolved()
+        c.advanceTick()                         // deferred → idle, this is the retry
+        XCTAssertTrue(c.mayWrite)
+
+        c.resolved()                            // a duplicate/late reply
+        XCTAssertTrue(c.mayWrite, "a stale reply must not close a reopened claim")
     }
 
     // MARK: Failure and unverified retry on the next tick
@@ -78,8 +135,8 @@ final class AutoWriteCoordinatorTests: XCTestCase {
         c.resolved()
         XCTAssertFalse(c.mayWrite)
 
-        c.clear()                               // tick
-        XCTAssertTrue(c.mayWrite, "a deferred write must get another attempt")
+        c.advanceTick()
+        XCTAssertTrue(c.mayWrite, "a concluded write must get another attempt")
     }
 
     /// The helper reported failure: `recoverStateAfterFailedWrite` resolves, then
@@ -91,22 +148,38 @@ final class AutoWriteCoordinatorTests: XCTestCase {
         c.resolved()                            // before the recovery re-read
         XCTAssertFalse(c.mayWrite, "the recovery read's adopt must not re-attempt")
 
-        c.clear()
+        c.advanceTick()
         XCTAssertTrue(c.mayWrite)
     }
 
-    /// The recovery guarantee: whatever state the claim is in, a tick reopens it.
-    /// This is what makes the claim safe to hold across an async boundary — no
-    /// outcome, and no missing outcome, can wedge the feature.
-    func testEveryStateIsClearedByATick() {
+    /// The full recovery guarantee, stated as a table: no state survives two
+    /// ticks. That bound is what makes a claim safe to hold across an async
+    /// boundary — no outcome, and no missing outcome, can wedge the feature.
+    func testNoStateSurvivesTwoTicks() {
         for state in [AutoWriteCoordinator.State.idle,
                       .inFlight(target: true),
                       .inFlight(target: false),
                       .deferred] {
             var c = AutoWriteCoordinator(state: state)
-            c.clear()
-            XCTAssertTrue(c.mayWrite, "a tick must reopen writing from \(state)")
+            c.advanceTick()
+            c.advanceTick()
+            XCTAssertTrue(c.mayWrite, "two ticks must reopen writing from \(state)")
         }
+    }
+
+    /// And the per-step transitions those two ticks are made of.
+    func testTickTransitions() {
+        var idle = AutoWriteCoordinator(state: .idle)
+        idle.advanceTick()
+        XCTAssertEqual(idle.state, .idle, "idle stays idle")
+
+        var inFlight = AutoWriteCoordinator(state: .inFlight(target: true))
+        inFlight.advanceTick()
+        XCTAssertEqual(inFlight.state, .deferred, "a live claim is demoted, not dropped")
+
+        var deferred = AutoWriteCoordinator(state: .deferred)
+        deferred.advanceTick()
+        XCTAssertEqual(deferred.state, .idle, "a concluded claim reopens")
     }
 
     // MARK: A user write supersedes an auto write

--- a/Tests/LidlessTests/AutoWriteCoordinatorTests.swift
+++ b/Tests/LidlessTests/AutoWriteCoordinatorTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+
+/// The claim auto mode holds on its outstanding system write.
+///
+/// These pin the four sequences that matter, each written as the turn-by-turn
+/// order the app actually runs them in. The helper path is the reason this type
+/// exists: `setEnabled` only dispatches there, so every step after "issued" can
+/// land in a later turn, and a claim released when the dispatching call returned
+/// would be no claim at all.
+final class AutoWriteCoordinatorTests: XCTestCase {
+
+    // MARK: A write in flight blocks a second one
+
+    /// The poll refreshes state and adopts what it observes while the helper is
+    /// still round-tripping. Adopting reconciles — and must not dispatch again.
+    func testInFlightWriteBlocksASecondWrite() {
+        var c = AutoWriteCoordinator()
+        XCTAssertTrue(c.mayWrite)
+
+        c.issued(target: true)                  // dispatched to the helper
+        XCTAssertFalse(c.mayWrite, "a refresh/adopt mid-flight must not dispatch again")
+        XCTAssertEqual(c.inFlightTarget, true)
+    }
+
+    /// The claim survives arbitrarily many observations, because on the helper
+    /// path there is no bound on how long the reply takes.
+    func testClaimSurvivesRepeatedObservationsWithinTheTurn() {
+        var c = AutoWriteCoordinator()
+        c.issued(target: true)
+        for _ in 0..<5 {
+            XCTAssertFalse(c.mayWrite)
+        }
+        XCTAssertEqual(c.state, .inFlight(target: true))
+    }
+
+    // MARK: A mismatch does not retry in the same turn
+
+    /// Read-back contradicts the write → resolve, adopt, reconcile. That
+    /// reconcile must find the door shut, or the mismatch can recur with nothing
+    /// bounding it but the stack.
+    func testMismatchDoesNotRetryInTheSameTurn() {
+        var c = AutoWriteCoordinator()
+        c.issued(target: true)
+
+        c.resolved()                            // applyVerification, before adopting
+        XCTAssertEqual(c.state, .deferred)
+        XCTAssertFalse(c.mayWrite, "adopt→reconcile must not dispatch a fresh write")
+    }
+
+    /// Resolving repeatedly — a verification and a later poll both concluding —
+    /// still can't reopen writing.
+    func testRepeatedResolutionCannotReopenWriting() {
+        var c = AutoWriteCoordinator()
+        c.issued(target: true)
+        c.resolved()
+        c.resolved()
+        XCTAssertEqual(c.state, .deferred)
+        XCTAssertFalse(c.mayWrite)
+    }
+
+    /// A late reply that lost its claim to `clear()` must not retroactively
+    /// defer the tick that replaced it.
+    func testResolutionWithoutAClaimIsIgnored() {
+        var c = AutoWriteCoordinator()
+        c.issued(target: true)
+        c.clear()                               // next tick took over
+        c.resolved()                            // superseded reply, arriving late
+        XCTAssertTrue(c.mayWrite, "a stale reply must not close a fresh tick's door")
+    }
+
+    // MARK: Failure and unverified retry on the next tick
+
+    /// `.unverified` keeps the pending verification but ends the write; the retry
+    /// belongs to the next tick, not to this turn.
+    func testUnverifiedWriteRetriesOnTheNextTick() {
+        var c = AutoWriteCoordinator()
+        c.issued(target: true)
+        c.resolved()
+        XCTAssertFalse(c.mayWrite)
+
+        c.clear()                               // tick
+        XCTAssertTrue(c.mayWrite, "a deferred write must get another attempt")
+    }
+
+    /// The helper reported failure: `recoverStateAfterFailedWrite` resolves, then
+    /// re-reads — and that read's adopt must not immediately re-attempt.
+    func testFailedWriteDefersUntilTheNextTick() {
+        var c = AutoWriteCoordinator()
+        c.issued(target: false)
+
+        c.resolved()                            // before the recovery re-read
+        XCTAssertFalse(c.mayWrite, "the recovery read's adopt must not re-attempt")
+
+        c.clear()
+        XCTAssertTrue(c.mayWrite)
+    }
+
+    /// The recovery guarantee: whatever state the claim is in, a tick reopens it.
+    /// This is what makes the claim safe to hold across an async boundary — no
+    /// outcome, and no missing outcome, can wedge the feature.
+    func testEveryStateIsClearedByATick() {
+        for state in [AutoWriteCoordinator.State.idle,
+                      .inFlight(target: true),
+                      .inFlight(target: false),
+                      .deferred] {
+            var c = AutoWriteCoordinator(state: state)
+            c.clear()
+            XCTAssertTrue(c.mayWrite, "a tick must reopen writing from \(state)")
+        }
+    }
+
+    // MARK: A user write supersedes an auto write
+
+    /// The user flips the toggle while auto mode's write is in flight. That write
+    /// loses the flag, and its reply will be rejected as superseded — so the claim
+    /// must go, or auto mode waits a tick on a reply that never resolves anything.
+    func testUserWriteSupersedesAnInFlightAutoWrite() {
+        var c = AutoWriteCoordinator()
+        c.issued(target: true)
+
+        c.clear()                               // setEnabled with a non-auto origin
+        XCTAssertTrue(c.mayWrite)
+        XCTAssertNil(c.inFlightTarget)
+    }
+
+    /// And the superseded auto reply, arriving afterwards, changes nothing.
+    func testSupersededAutoReplyDoesNotDisturbTheUserWrite() {
+        var c = AutoWriteCoordinator()
+        c.issued(target: true)
+        c.clear()                               // user write took over
+
+        c.resolved()                            // the old auto reply, finally landing
+        XCTAssertTrue(c.mayWrite)
+        XCTAssertEqual(c.state, .idle)
+    }
+}

--- a/Tests/LidlessTests/SafetyEvaluatorTests.swift
+++ b/Tests/LidlessTests/SafetyEvaluatorTests.swift
@@ -4,6 +4,13 @@ final class SafetyEvaluatorTests: XCTestCase {
 
     private let defaults = SafetySettings.default
 
+    /// Defaults with auto-enable mode switched on.
+    private var auto: SafetySettings {
+        var s = SafetySettings.default
+        s.autoEnableWhenCharging = true
+        return s
+    }
+
     func testSafeWhenChargingAndCool() {
         let info = BatteryInfo(percent: 50, onAC: true)
         XCTAssertNil(SafetyEvaluator.reasonToDisable(battery: info, thermalSerious: false, settings: defaults))
@@ -51,6 +58,13 @@ final class SafetyEvaluatorTests: XCTestCase {
         XCTAssertEqual(SafetyReason.highThermal.message, "Auto-paused: the Mac is running hot.")
         XCTAssertEqual(SafetyReason.notCharging.message, "Auto-paused: not on charger.")
         XCTAssertEqual(SafetyReason.lowBattery(12).message, "Auto-paused: battery 12% on battery power.")
+        XCTAssertEqual(SafetyReason.notOnPower.message, "Auto-paused: not connected to power.")
+    }
+
+    func testNotOnPowerPhrasing() {
+        XCTAssertEqual(SafetyReason.notOnPower.blockedMessage,
+                       "Connect your Mac to power to keep it awake.")
+        XCTAssertEqual(SafetyReason.notOnPower.checkLabel, "Not connected to power")
     }
 
     // MARK: Low-battery cutoff = "Never" (0)
@@ -80,11 +94,76 @@ final class SafetyEvaluatorTests: XCTestCase {
             battery: BatteryInfo(percent: 100, onAC: true), thermalSerious: true, settings: defaults))
     }
 
-    func testAutoEnableBlockedByOnlyWhileChargingIsMootOnPower() {
+    func testOnlyWhileChargingIsMootOnPower() {
         var s = defaults
         s.onlyWhileCharging = true
         XCTAssertTrue(AutoEnablePolicy.canActivate(
             battery: BatteryInfo(percent: 50, onAC: true), thermalSerious: false, settings: s))
+    }
+
+    // MARK: AutoEnablePolicy.target — the state reconcile() acts on
+
+    /// `auto` mode off: never our call to make, whatever else is true.
+    func testTargetIsNilWhenAutoModeOff() {
+        XCTAssertNil(AutoEnablePolicy.target(
+            armed: true, currentlyEnabled: false,
+            battery: BatteryInfo(percent: 90, onAC: true),
+            thermalSerious: false, settings: defaults))
+    }
+
+    func testTargetTurnsOnWhenArmedAndPluggedIn() {
+        XCTAssertEqual(AutoEnablePolicy.target(
+            armed: true, currentlyEnabled: false,
+            battery: BatteryInfo(percent: 90, onAC: true),
+            thermalSerious: false, settings: auto), true)
+    }
+
+    func testTargetTurnsOffWhenUnplugged() {
+        XCTAssertEqual(AutoEnablePolicy.target(
+            armed: true, currentlyEnabled: true,
+            battery: BatteryInfo(percent: 90, onAC: false),
+            thermalSerious: false, settings: auto), false)
+    }
+
+    func testTargetTurnsOffWhenDisarmed() {
+        XCTAssertEqual(AutoEnablePolicy.target(
+            armed: false, currentlyEnabled: true,
+            battery: BatteryInfo(percent: 90, onAC: true),
+            thermalSerious: false, settings: auto), false)
+    }
+
+    func testTargetTurnsOffWhenRunningHot() {
+        XCTAssertEqual(AutoEnablePolicy.target(
+            armed: true, currentlyEnabled: true,
+            battery: BatteryInfo(percent: 90, onAC: true),
+            thermalSerious: true, settings: auto), false)
+    }
+
+    /// The poll runs every 30s; a target equal to the live state must report
+    /// "nothing to do" so we never rewrite the system flag on an idle tick.
+    func testTargetIsNilWhenAlreadyCorrect() {
+        XCTAssertNil(AutoEnablePolicy.target(
+            armed: true, currentlyEnabled: true,
+            battery: BatteryInfo(percent: 90, onAC: true),
+            thermalSerious: false, settings: auto))
+        XCTAssertNil(AutoEnablePolicy.target(
+            armed: false, currentlyEnabled: false,
+            battery: BatteryInfo(percent: 90, onAC: true),
+            thermalSerious: false, settings: auto))
+        XCTAssertNil(AutoEnablePolicy.target(
+            armed: true, currentlyEnabled: false,
+            battery: BatteryInfo(percent: 90, onAC: false),
+            thermalSerious: false, settings: auto))
+    }
+
+    /// Armed and plugged in, but the cutoff can't fire on power — so it stays on.
+    func testTargetIgnoresCutoffWhileOnPower() {
+        var s = auto
+        s.lowBatteryThreshold = 95
+        XCTAssertEqual(AutoEnablePolicy.target(
+            armed: true, currentlyEnabled: false,
+            battery: BatteryInfo(percent: 10, onAC: true),
+            thermalSerious: false, settings: s), true)
     }
 
     // MARK: allUnmetReasons
@@ -114,6 +193,23 @@ final class SafetyEvaluatorTests: XCTestCase {
         let reasons = SafetyEvaluator.allUnmetReasons(
             battery: info, thermalSerious: false, settings: s, requirePower: true)
         XCTAssertEqual(reasons, [.notOnPower])
+    }
+
+    /// `reasonToDisable` and `allUnmetReasons` share one low-battery predicate;
+    /// this pins them together across the whole threshold boundary so a future
+    /// edit to one can't quietly diverge from the other.
+    func testLowBatteryAgreesAcrossBothEvaluators() {
+        var s = defaults
+        s.lowBatteryThreshold = 20
+        for percent in [0, 1, 19, 20, 21, 100] {
+            let info = BatteryInfo(percent: percent, onAC: false)
+            let single = SafetyEvaluator.reasonToDisable(
+                battery: info, thermalSerious: false, settings: s) == .lowBattery(percent)
+            let listed = SafetyEvaluator.allUnmetReasons(
+                battery: info, thermalSerious: false, settings: s,
+                requirePower: false).contains(.lowBattery(percent))
+            XCTAssertEqual(single, listed, "disagreement at \(percent)%")
+        }
     }
 
     func testAllUnmetReasonsIncludesThermal() {

--- a/Tests/LidlessTests/SafetyEvaluatorTests.swift
+++ b/Tests/LidlessTests/SafetyEvaluatorTests.swift
@@ -53,6 +53,77 @@ final class SafetyEvaluatorTests: XCTestCase {
         XCTAssertEqual(SafetyReason.lowBattery(12).message, "Auto-paused: battery 12% on battery power.")
     }
 
+    // MARK: Low-battery cutoff = "Never" (0)
+
+    func testThresholdZeroNeverTriggersLowBattery() {
+        var s = defaults
+        s.lowBatteryThreshold = 0
+        let info = BatteryInfo(percent: 1, onAC: false)
+        XCTAssertNil(SafetyEvaluator.reasonToDisable(battery: info, thermalSerious: false, settings: s))
+    }
+
+    // MARK: AutoEnablePolicy
+
+    func testAutoEnableActivatesOnPowerWhenSafe() {
+        XCTAssertTrue(AutoEnablePolicy.canActivate(
+            battery: BatteryInfo(percent: 5, onAC: true), thermalSerious: false, settings: defaults))
+    }
+
+    func testAutoEnableNeverActivatesOnBattery() {
+        // Even at full charge, auto mode requires external power.
+        XCTAssertFalse(AutoEnablePolicy.canActivate(
+            battery: BatteryInfo(percent: 100, onAC: false), thermalSerious: false, settings: defaults))
+    }
+
+    func testAutoEnableBlockedByThermalOnPower() {
+        XCTAssertFalse(AutoEnablePolicy.canActivate(
+            battery: BatteryInfo(percent: 100, onAC: true), thermalSerious: true, settings: defaults))
+    }
+
+    func testAutoEnableBlockedByOnlyWhileChargingIsMootOnPower() {
+        var s = defaults
+        s.onlyWhileCharging = true
+        XCTAssertTrue(AutoEnablePolicy.canActivate(
+            battery: BatteryInfo(percent: 50, onAC: true), thermalSerious: false, settings: s))
+    }
+
+    // MARK: allUnmetReasons
+
+    func testAllUnmetReasonsEmptyWhenSafeOnPower() {
+        let info = BatteryInfo(percent: 80, onAC: true)
+        XCTAssertTrue(SafetyEvaluator.allUnmetReasons(
+            battery: info, thermalSerious: false, settings: defaults, requirePower: true).isEmpty)
+    }
+
+    func testAllUnmetReasonsListsPowerAndBatteryOffPower() {
+        var s = defaults
+        s.lowBatteryThreshold = 50
+        let info = BatteryInfo(percent: 34, onAC: false)
+        let reasons = SafetyEvaluator.allUnmetReasons(
+            battery: info, thermalSerious: false, settings: s, requirePower: true)
+        XCTAssertEqual(reasons, [.notOnPower, .lowBattery(34)])
+    }
+
+    func testAllUnmetReasonsDedupesPowerBullet() {
+        // With requirePower and onlyWhileCharging both implying power, only the
+        // power bullet appears — never both it and .notCharging.
+        var s = defaults
+        s.onlyWhileCharging = true
+        s.lowBatteryThreshold = 0
+        let info = BatteryInfo(percent: 90, onAC: false)
+        let reasons = SafetyEvaluator.allUnmetReasons(
+            battery: info, thermalSerious: false, settings: s, requirePower: true)
+        XCTAssertEqual(reasons, [.notOnPower])
+    }
+
+    func testAllUnmetReasonsIncludesThermal() {
+        let info = BatteryInfo(percent: 90, onAC: false)
+        let reasons = SafetyEvaluator.allUnmetReasons(
+            battery: info, thermalSerious: true, settings: defaults, requirePower: true)
+        XCTAssertEqual(reasons.first, .highThermal)
+        XCTAssertTrue(reasons.contains(.notOnPower))
+    }
+
     // MARK: SettingsStore
 
     func testSettingsStoreDefaultsWhenUnseeded() {
@@ -71,8 +142,20 @@ final class SafetyEvaluatorTests: XCTestCase {
         s.onlyWhileCharging = true
         s.pauseOnHighThermal = false
         s.lowBatteryThreshold = 35
+        s.autoEnableWhenCharging = true
         store.save(s)
         XCTAssertEqual(store.load(), s)
+        d.removePersistentDomain(forName: suite)
+    }
+
+    func testArmedRoundTrip() {
+        let suite = "test.lidless.armed"
+        let d = UserDefaults(suiteName: suite)!
+        d.removePersistentDomain(forName: suite)
+        let store = SettingsStore(defaults: d)
+        XCTAssertFalse(store.loadArmed())
+        store.saveArmed(true)
+        XCTAssertTrue(store.loadArmed())
         d.removePersistentDomain(forName: suite)
     }
 }


### PR DESCRIPTION
Rebases and continues #20 (@justicefreed's auto-enable work) on top of `main`.
PR #20 is left untouched — its branch lives on a fork, and this history was
rebased, so updating it in place would have meant force-pushing over someone
else's branch.

## Why this isn't just a rebase

#20 was written against `f257104`. `main` has since taken #24, which rewrote the
very state machine it touches:

| | #20's base | `main` |
|---|---|---|
| write API | `setEnabled(_:note:userInitiated: Bool = false)` | `setEnabled(_:note:origin: SetOrigin = .user)` |
| default | **quiet** | **loud** — alerts, clears `externalNotice` |
| `refreshState()` | async via `helper.getState` | **synchronous** |
| reconcile/drift | — | `StateReconciler` + `adoptSystemState` |

The rebase merges cleanly and *still* changes behaviour: the trailing parameter
kept its position but flipped its default, so `setEnabled(shouldBeOn, note: nil)`
in `reconcile()` compiles untouched while quietly acquiring the right to raise a
modal from a poll tick. One call site errors, the other doesn't.

## What changed on top of the rebase

**Origin.** New `SetOrigin.auto` for the derived path — it can turn keep-awake
*on*, which `.safety` never does, and fires unprompted, which nothing else with
alert rights does.

**Launch.** Dropped `force: true`. It existed because `refreshState()` used to
answer asynchronously; it doesn't any more, so the ordinary comparison is sound
and an unarmed launch stops writing the flag for no reason.

**Ownership.** Adopting an outside change settles through `reconcile()` in auto
mode, so the toggle can't jump to a value the next tick undoes. The decision
moved to `AutoEnablePolicy.target`, which returns nil for "already correct".

**Arming.** Opting in arms the feature. Inheriting the live state meant switching
it on while keep-awake happened to be off — the case the feature exists for —
visibly did nothing.

### The write lifecycle, which took three passes to get right

Each of these was a real defect found in review, and each is worth reading as a
sequence rather than a diff:

1. A reentrancy guard scoped to the issuing call is meaningless on the helper
   path, where `setEnabled` only *dispatches*. Replaced with a claim spanning
   issue → resolve (`AutoWriteCoordinator`).
2. Clearing that claim every tick reopened the race from the other side: a tick
   landing moments after a dispatch would write again alongside a live request.
   Ticks now *advance* the claim — a live one is demoted, not dropped.
3. Deciding against the shown state dropped intent expressed mid-flight.
   Disarming while an "on" write travelled compared `false` against a still-
   `false` `isEnabled`, concluded nothing needed doing, and returned **without
   claiming a mutation** — so the earlier write landed and turned keep-awake on
   moments after the user turned it off. Decisions now run against the
   *effective* state.

Leaving auto mode had the same hole from the other side, and settling it needs a
write that can't be refused — hence `SafetySnapshot`: the safety check still
runs, but against the conditions the decision was made from, since a refusal
returns before claiming a mutation and supersedes nothing.

## UI

Cutoff greys out under auto mode for the same reason it does under "Only while
charging"; the auto-off picker says why it's inert instead of silently no-opping;
leaving auto mode re-arms the countdown it suppressed; the cutoff slider commits
on drag end rather than once per 5% of travel; the warning list reads the same
battery sample the decision did.

## Verification

Per `CLAUDE.md` (Actions unavailable):

```
xcodegen generate
xcodebuild test -scheme Lidless-CI -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
xcodebuild build -scheme Lidless -destination 'generic/platform=macOS' -configuration Debug CODE_SIGNING_ALLOWED=NO
```

**117 tests, 0 failures** (from 27 on `main`, 37 on #20) — `** TEST SUCCEEDED **`
and `** BUILD SUCCEEDED **`.

Manual smoke test on a dev build (`com.nghialuong.lidless.dev`), all seven cases
passed, with `pmset` and `UserDefaults` read independently at each step rather
than taken from the UI. Two results are worth more than the rest:

- **Disarm then reconnect power**: stayed off across 66s (two-plus tick
  intervals) — the "un-turn-off-able toggle" trap avoided.
- **Relaunch with conditions lapsed**: a state left on by a prior session was
  reclaimed **4.6s** after launch, far below the 30s first tick, which is direct
  evidence that dropping `force: true` did not cost the launch reclaim.

### Stated plainly, since a green checklist can overstate itself

- The pending-write race the coordinator exists for is **not** reachable by hand
  — a healthy helper round-trips in milliseconds. It's covered by
  `AutoPendingWriteTests`, not by the smoke test.
- The drift-from-Terminal case confirms the end state but not *which* path
  reclaimed it; the measurement was lost.
- One launch took 17.3s instead of 4.6s. Not reproduced, cause unknown, recorded
  rather than explained away.
- Reconcile latency is bounded by the existing 30s poll, and App Nap stretches it
  — one unplug took >40s to take effect. Pre-existing; `BatteryMonitor` already
  carries `TODO (M2): switch to IOPowerSources for live notifications`.
- `AppState.toggle()` is now dead code (#20 replaced its call site). Left in
  place as out of scope.
- The `AppState` wiring — the ordering of `resolved()` before `adoptSystemState`,
  and snapshot threading — is covered by reading, not tests: `AppState` is
  `@MainActor` with hard-wired `HelperManager`/`PowerManager`/`BatteryMonitor`.
  The pure decisions were extracted to `Shared/` precisely so the parts that
  could be tested are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
