### PR TITLE
Wake the Mac on a timer, then leave no trace

### DIFF
--- a/Sources/Helper/HelperService.swift
+++ b/Sources/Helper/HelperService.swift
@@ -3,8 +3,23 @@ import Foundation
 final class HelperListenerDelegate: NSObject, NSXPCListenerDelegate {
     private let service = HelperService()
 
+    /// The app this helper belongs to, from the label launchd started us with.
+    private let appBundleID = LidlessHelper.appBundleID(
+        fromLabel: ProcessInfo.processInfo.environment[LidlessHelper.machLabelEnvKey]
+            ?? LidlessHelper.fallbackLabel
+    )
+
     func listener(_ listener: NSXPCListener,
                   shouldAcceptNewConnection newConnection: NSXPCConnection) -> Bool {
+        // Demand the peer be our app before handing it a root-privileged
+        // object. The Mach service is reachable by anything running on the
+        // machine, so this is the only thing standing between "the app asked"
+        // and "some process asked". Set before `resume()`, as the API requires;
+        // messages from anything that doesn't match invalidate the connection
+        // rather than reaching the exported object.
+        newConnection.setCodeSigningRequirement(
+            LidlessHelper.codeSigningRequirement(appBundleID: appBundleID)
+        )
         newConnection.exportedInterface = NSXPCInterface(with: LidlessHelperProtocol.self)
         newConnection.exportedObject = service
         newConnection.resume()

--- a/Sources/Helper/HelperService.swift
+++ b/Sources/Helper/HelperService.swift
@@ -69,6 +69,11 @@ final class HelperService: NSObject, LidlessHelperProtocol {
 
     func scheduleWake(at date: Date, withReply reply: @escaping (Date?, String?) -> Void) {
         queue.async {
+            // Drop any sub-second part before writing. This is an entry point,
+            // so it can't assume the caller already did — and a fractional date
+            // would schedule successfully, come back from powerd rounded, and
+            // then fail the check below for a wake that really is on the Mac.
+            let target = ScheduledWake.wholeSecond(date)
             // Clear ours first, then write. The ordering is what makes an
             // interrupted call safe: if this process dies between the two
             // steps the machine is left with no wake at all, which is a Mac
@@ -79,7 +84,7 @@ final class HelperService: NSObject, LidlessHelperProtocol {
                 reply(nil, error)
                 return
             }
-            let status = WakeScheduler.schedule(date, ownerID: self.wakeOwnerID)
+            let status = WakeScheduler.schedule(target, ownerID: self.wakeOwnerID)
             guard status == kIOReturnSuccess else {
                 reply(nil, WakeScheduler.describe(status))
                 return
@@ -92,11 +97,18 @@ final class HelperService: NSObject, LidlessHelperProtocol {
                 return
             }
             let ours = ScheduledWake.ownedWakeDates(events: events, ownerID: self.wakeOwnerID)
-            guard ours == [date] else {
+            // Exactly one, at the time we asked for — the invariant this whole
+            // method exists to maintain, checked against the machine rather
+            // than assumed from a return code.
+            guard ours.count == 1, let scheduled = ours.first,
+                  ScheduledWake.isSameWakeInstant(scheduled, target) else {
                 reply(nil, "The wake time didn’t take effect.")
                 return
             }
-            reply(date, nil)
+            // Reply with what powerd holds, not with what we were handed.
+            // powerd decides what got scheduled; echoing the input back would
+            // report agreement we never actually checked for.
+            reply(scheduled, nil)
         }
     }
 

--- a/Sources/Helper/HelperService.swift
+++ b/Sources/Helper/HelperService.swift
@@ -52,11 +52,99 @@ final class HelperService: NSObject, LidlessHelperProtocol {
     }
 
     func version(withReply reply: @escaping (String) -> Void) {
-        reply("0.1.0")
+        reply("0.2.0")
+    }
+
+    // MARK: Scheduled wake
+
+    /// The owner id stamped onto every power event this helper creates, derived
+    /// from our own launchd label rather than accepted from the caller — see
+    /// the note on `scheduleWake` in `LidlessHelperProtocol`. Debug and Release
+    /// have different labels, so their wakes can't see or cancel each other's.
+    private lazy var wakeOwnerID: String = {
+        let label = ProcessInfo.processInfo.environment[LidlessHelper.machLabelEnvKey]
+            ?? LidlessHelper.fallbackLabel
+        return ScheduledWake.ownerID(fromMachLabel: label)
+    }()
+
+    func scheduleWake(at date: Date, withReply reply: @escaping (Date?, String?) -> Void) {
+        queue.async {
+            // Clear ours first, then write. The ordering is what makes an
+            // interrupted call safe: if this process dies between the two
+            // steps the machine is left with no wake at all, which is a Mac
+            // that quietly doesn't wake up. The other order would leave two,
+            // which is a Mac that wakes at a time nothing ever told the user
+            // about — much harder to notice and much harder to explain.
+            if let error = self.clearOwnedWakes() {
+                reply(nil, error)
+                return
+            }
+            let status = WakeScheduler.schedule(date, ownerID: self.wakeOwnerID)
+            guard status == kIOReturnSuccess else {
+                reply(nil, WakeScheduler.describe(status))
+                return
+            }
+            // Read back rather than trust the return code: a success status
+            // says the call was accepted, not that the machine now holds this
+            // event. Same rule the app follows after `setKeepAwake`.
+            guard let events = WakeScheduler.copyEvents() else {
+                reply(nil, "Couldn’t read the wake schedule back.")
+                return
+            }
+            let ours = ScheduledWake.ownedWakeDates(events: events, ownerID: self.wakeOwnerID)
+            guard ours == [date] else {
+                reply(nil, "The wake time didn’t take effect.")
+                return
+            }
+            reply(date, nil)
+        }
+    }
+
+    func cancelScheduledWake(withReply reply: @escaping (Bool, String?) -> Void) {
+        queue.async {
+            if let error = self.clearOwnedWakes() {
+                reply(false, error)
+                return
+            }
+            reply(true, nil)
+        }
+    }
+
+    /// Cancel every wake carrying our owner id, then confirm none remain.
+    /// Returns nil on success, or a message describing what went wrong.
+    ///
+    /// Only ever passes dates that `ownedWakeDates` attributed to us, so a
+    /// power event belonging to macOS or to the user is never an argument to
+    /// `IOPMCancelScheduledPowerEvent`. Must be called on `queue`.
+    private func clearOwnedWakes() -> String? {
+        guard let events = WakeScheduler.copyEvents() else {
+            return "Couldn’t read the wake schedule."
+        }
+        for date in ScheduledWake.ownedWakeDates(events: events, ownerID: wakeOwnerID) {
+            let status = WakeScheduler.cancel(date, ownerID: wakeOwnerID)
+            guard status == kIOReturnSuccess || status == kIOReturnNotFound else {
+                return WakeScheduler.describe(status)
+            }
+        }
+        guard let after = WakeScheduler.copyEvents() else {
+            return "Couldn’t read the wake schedule back."
+        }
+        guard ScheduledWake.ownedWakeDates(events: after, ownerID: wakeOwnerID).isEmpty else {
+            return "A previous wake time couldn’t be cleared."
+        }
+        return nil
     }
 
     // MARK: Watchdog
 
+    /// Restores normal sleep when the app stops checking in.
+    ///
+    /// Scheduled wakes are deliberately outside its remit. The watchdog exists
+    /// because a Mac stuck awake is a Mac cooking itself in a bag; a pending
+    /// wake has no such failure mode, and the whole point of handing the
+    /// deadline to powerd is that it outlives the app. Clearing it here would
+    /// mean an alarm the user set silently evaporates because they quit a
+    /// menu-bar app.
     private func startWatchdog() {
         let timer = DispatchSource.makeTimerSource(queue: queue)
         timer.schedule(deadline: .now() + 30, repeating: 30)

--- a/Sources/Helper/WakeScheduler.swift
+++ b/Sources/Helper/WakeScheduler.swift
@@ -1,0 +1,49 @@
+import Foundation
+import IOKit.pwr_mgt
+
+/// Thin adapter over the IOKit scheduled-power-event calls.
+///
+/// Deliberately as dumb as it can be: three functions, no filtering, no policy,
+/// no interpretation. Nothing here can be unit-tested — `IOPMSchedulePowerEvent`
+/// and `IOPMCancelScheduledPowerEvent` must run as root and change real machine
+/// state — so anything worth testing lives in `ScheduledWake` instead, and this
+/// file is kept small enough to review by eye.
+enum WakeScheduler {
+
+    /// Every pending power event on the Mac, ours and everyone else's.
+    ///
+    /// Returns nil only when the array comes back in a shape we can't read.
+    /// A NULL result is *not* that case: IOKit documents NULL as "there are no
+    /// scheduled events", which is a real answer, so it maps to `[]`. Callers
+    /// need the two kept apart — an unreadable schedule must never be reported
+    /// as an empty one.
+    static func copyEvents() -> [[String: Any]]? {
+        guard let raw = IOPMCopyScheduledPowerEvents() else { return [] }
+        return (raw.takeRetainedValue() as? [[String: Any]])
+    }
+
+    @discardableResult
+    static func schedule(_ date: Date, ownerID: String) -> IOReturn {
+        IOPMSchedulePowerEvent(date as CFDate,
+                               ownerID as CFString,
+                               ScheduledWake.eventType as CFString)
+    }
+
+    @discardableResult
+    static func cancel(_ date: Date, ownerID: String) -> IOReturn {
+        IOPMCancelScheduledPowerEvent(date as CFDate,
+                                      ownerID as CFString,
+                                      ScheduledWake.eventType as CFString)
+    }
+
+    /// Human-readable form of an IOKit status, for the error we send back to
+    /// the app. `kIOReturnNotPrivileged` is called out by name because it's the
+    /// one failure with an obvious cause — this ran somewhere other than root.
+    static func describe(_ status: IOReturn) -> String {
+        switch status {
+        case kIOReturnNotPrivileged: return "Not permitted to change the wake schedule."
+        case kIOReturnBadArgument:   return "The system rejected the wake time."
+        default:                     return String(format: "IOKit error 0x%08x", UInt32(bitPattern: status))
+        }
+    }
+}

--- a/Sources/Lidless/AppState.swift
+++ b/Sources/Lidless/AppState.swift
@@ -1093,6 +1093,16 @@ final class AppState: ObservableObject {
         // Cheap (a single unprivileged IOKit read) and it's what notices a wake
         // that fired, or one set from another copy of the app.
         refreshScheduledWake()
+        // Re-ask whenever we don't have a good answer. The probe at launch can
+        // miss — a login-item start while the machine is still busy, or a lid
+        // closed the moment the app opens, which is this app's whole audience —
+        // and `recheckHelper` only re-probes on the unusable→usable edge, which
+        // by then has already passed. Without this a single early timeout would
+        // read as "the helper isn't responding" for the rest of the session
+        // while that same helper answers every heartbeat.
+        if helperInstalled, scheduledWakeSupport != .supported {
+            refreshScheduledWakeSupport()
+        }
         if settings.autoEnableWhenCharging {
             reconcile()             // refreshes the battery sample itself
         } else {

--- a/Sources/Lidless/AppState.swift
+++ b/Sources/Lidless/AppState.swift
@@ -66,6 +66,28 @@ final class AppState: ObservableObject {
     /// Whether the user has finished first-run onboarding (persisted).
     @Published var onboardingComplete = false
 
+    // MARK: Scheduled wake
+
+    /// When the Mac is set to wake itself, or nil when nothing is scheduled.
+    ///
+    /// Not persisted anywhere: powerd holds the event, so powerd is the source
+    /// of truth. That's what lets the countdown survive a quit, a crash, or a
+    /// reboot without any state of our own to keep in step.
+    @Published private(set) var scheduledWakeDate: Date?
+    /// True when the schedule couldn't be read. Distinct from "nothing
+    /// scheduled" — the UI must not turn an unreadable answer into a claim.
+    @Published private(set) var scheduledWakeUnknown = false
+    /// Countdown like `12:41`, shown beside the absolute wake time.
+    @Published private(set) var scheduledWakeRemaining = ""
+    /// Whether the controls are usable, and if not, why.
+    @Published private(set) var scheduledWakeSupport: ScheduledWake.SupportState = .helperNotInstalled
+    /// Its own channel, so a wake failure can't wipe a keep-awake safety note.
+    @Published var scheduledWakeError: String?
+
+    /// True while a schedule/cancel is in flight, so the UI can stop the user
+    /// firing a second one at the helper before the first has answered.
+    @Published private(set) var scheduledWakeBusy = false
+
     private let helper = HelperManager()
     /// Reads the flag on every path — `pmset -g` needs no privileges — and also
     /// writes it when the helper isn't installed.
@@ -97,6 +119,14 @@ final class AppState: ObservableObject {
     private var batteryTimer: Timer?
     private var heartbeatTimer: Timer?
     private var autoOffTimer: Timer?
+    /// Its own timer, not shared with `autoOffTimer`: the two countdowns have
+    /// unrelated lifetimes — one dies with the app, the other outlives it — and
+    /// driving them from one timer would tie those lifetimes together.
+    private var scheduledWakeTimer: Timer?
+    /// Rejects helper replies that a newer schedule/cancel has superseded.
+    private var scheduledWakeGeneration = 0
+    private var didWakeObserver: NSObjectProtocol?
+    private var clockChangeObserver: NSObjectProtocol?
 
     /// Last-known "helper is usable" value, so we can detect it flipping on at
     /// runtime (right after the user approves it) and prompt a restart.
@@ -151,6 +181,25 @@ final class AppState: ObservableObject {
                 self?.refreshState()
             }
         }
+        // Adopt whatever wake powerd is already holding — from a previous run,
+        // or from this app before it was quit. Nothing about it was persisted
+        // by us, so this read *is* how the countdown comes back.
+        refreshScheduledWakeSupport()
+        refreshScheduledWake()
+        // The Mac waking is the moment a scheduled wake either fired or didn't,
+        // so it's the moment the schedule is most likely to have changed under
+        // us. A clock change doesn't move the event — it's an absolute instant —
+        // but it does make the rendered countdown wrong until we redraw it.
+        didWakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.refreshScheduledWake() }
+        }
+        clockChangeObserver = NotificationCenter.default.addObserver(
+            forName: NSNotification.Name.NSSystemClockDidChange, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.refreshScheduledWake() }
+        }
         // First launch shows onboarding once (persisted so closing it early won't
         // re-nag). A relaunch triggered mid-onboarding resumes the flow instead.
         if store.loadResumeOnboarding() {
@@ -166,6 +215,12 @@ final class AppState: ObservableObject {
     deinit {
         if let didBecomeActiveObserver {
             NotificationCenter.default.removeObserver(didBecomeActiveObserver)
+        }
+        if let didWakeObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(didWakeObserver)
+        }
+        if let clockChangeObserver {
+            NotificationCenter.default.removeObserver(clockChangeObserver)
         }
     }
 
@@ -411,6 +466,7 @@ final class AppState: ObservableObject {
         helperWasUsable = usingHelper
         guard !wasUsable, usingHelper else { return }
         refreshState()
+        refreshScheduledWakeSupport()
         promptRestartAfterHelperEnabled()
     }
 
@@ -744,6 +800,10 @@ final class AppState: ObservableObject {
             guard let self else { return }
             self.refreshHelperStatus()
             self.storeCurrentHelperBuild()
+            // A reinstall is exactly how an outdated helper becomes a current
+            // one, so re-ask what it is now rather than leaving the wake
+            // controls disabled until the next launch.
+            self.refreshScheduledWakeSupport()
             if let error {
                 self.lastError = error.localizedDescription
             } else if self.helper.requiresApproval {
@@ -814,6 +874,171 @@ final class AppState: ObservableObject {
         autoOffRemaining = AutoOff.formatCountdown(AutoOff.remaining(deadline: deadline, now: Date()))
     }
 
+    // MARK: Scheduled wake
+
+    /// The owner id our wake events carry. Derived from this app's bundle id,
+    /// which is how the `.dev` build and the release build stay out of each
+    /// other's schedule. Must agree with the helper's own derivation.
+    private var wakeOwnerID: String {
+        ScheduledWake.ownerID(appBundleID: Bundle.main.bundleIdentifier ?? "com.nghialuong.lidless")
+    }
+
+    /// Ask the helper what version it is, and decide whether the controls work.
+    ///
+    /// Everyone upgrading into this feature already has an older helper running
+    /// whose exported object has no `scheduleWake:` — calling it doesn't fail,
+    /// it just never replies, so without this gate every attempt would be a
+    /// six-second wait ending in an apology.
+    private func refreshScheduledWakeSupport() {
+        guard helperInstalled else {
+            scheduledWakeSupport = .helperNotInstalled
+            return
+        }
+        helper.fetchVersion { [weak self] version in
+            guard let self else { return }
+            self.scheduledWakeSupport = ScheduledWake.supportState(helperInstalled: self.helperInstalled,
+                                                                    version: version)
+        }
+    }
+
+    /// Read the system's power schedule and bring the UI into step with it.
+    ///
+    /// Also repairs what it finds. Leftovers happen — an event powerd hasn't
+    /// purged, or duplicates from a write interrupted between its sweep and its
+    /// schedule — and the repair is expressed with the same two calls the
+    /// feature already has, because `scheduleWake` sweeps ours before writing.
+    func refreshScheduledWake() {
+        let action = ScheduledWake.reconcile(events: WakeScheduleReader.copyEvents(),
+                                             ownerID: wakeOwnerID,
+                                             now: Date())
+        switch action {
+        case .unknown:
+            // Say nothing about the schedule we couldn't read. Keeping the last
+            // known date and flagging it unconfirmed is honest; replacing it
+            // with "no wake scheduled" would be a claim we have no basis for.
+            scheduledWakeUnknown = true
+        case .none:
+            scheduledWakeUnknown = false
+            setScheduledWake(nil)
+        case .pending(let date):
+            scheduledWakeUnknown = false
+            setScheduledWake(date)
+        case .repair(let keep):
+            scheduledWakeUnknown = false
+            setScheduledWake(keep)
+            // Re-assert rather than reach for a cancel-these-dates call: this
+            // ends with exactly one event, at the time now on screen.
+            guard scheduledWakeSupport == .supported, !scheduledWakeBusy else { return }
+            writeScheduledWake(keep, quiet: true)
+        case .clear:
+            scheduledWakeUnknown = false
+            setScheduledWake(nil)
+            guard scheduledWakeSupport == .supported, !scheduledWakeBusy else { return }
+            let generation = beginScheduledWakeWrite()
+            helper.cancelScheduledWake { [weak self] _, _ in
+                // Quiet: this is housekeeping the user never asked for, and a
+                // failure means only that some debris is still sitting there —
+                // nothing they could act on, and nothing that affects a wake
+                // they're waiting for.
+                self?.finishScheduledWakeWrite(generation)
+            }
+        }
+    }
+
+    /// Schedule a wake `minutes` from now, replacing any wake already set.
+    func scheduleWake(minutes: Int) {
+        guard scheduledWakeSupport == .supported else { return }
+        writeScheduledWake(ScheduledWake.wakeDate(from: Date(), minutes: minutes), quiet: false)
+    }
+
+    private func writeScheduledWake(_ date: Date, quiet: Bool) {
+        let generation = beginScheduledWakeWrite()
+        if !quiet { scheduledWakeError = nil }
+        helper.scheduleWake(at: date) { [weak self] confirmed, error in
+            guard let self, self.finishScheduledWakeWrite(generation) else { return }
+            if let confirmed {
+                // The date the helper read back out of powerd, not the one we
+                // asked for — the system decides what got scheduled.
+                self.scheduledWakeUnknown = false
+                self.setScheduledWake(confirmed)
+            } else {
+                if !quiet { self.scheduledWakeError = error ?? "Couldn’t set the wake time." }
+                // The write failed, so we know nothing reliable about the
+                // schedule — it may have landed anyway. Go and look.
+                self.refreshScheduledWake()
+            }
+        }
+    }
+
+    /// Remove the scheduled wake. Only ever from the user pressing Cancel —
+    /// quitting the app deliberately leaves the wake in place, the same way
+    /// quitting a clock app doesn't cancel its alarms.
+    func cancelScheduledWake() {
+        guard scheduledWakeSupport == .supported else { return }
+        let generation = beginScheduledWakeWrite()
+        scheduledWakeError = nil
+        helper.cancelScheduledWake { [weak self] ok, error in
+            guard let self, self.finishScheduledWakeWrite(generation) else { return }
+            if ok {
+                self.scheduledWakeUnknown = false
+                self.setScheduledWake(nil)
+            } else {
+                self.scheduledWakeError = error ?? "Couldn’t clear the wake time."
+                self.refreshScheduledWake()
+            }
+        }
+    }
+
+    /// Claim the write slot and invalidate any reply still travelling.
+    private func beginScheduledWakeWrite() -> Int {
+        scheduledWakeGeneration += 1
+        scheduledWakeBusy = true
+        return scheduledWakeGeneration
+    }
+
+    /// Returns false if this reply has been superseded, in which case the
+    /// caller must not touch state — a newer request owns it now.
+    @discardableResult
+    private func finishScheduledWakeWrite(_ generation: Int) -> Bool {
+        guard generation == scheduledWakeGeneration else { return false }
+        scheduledWakeBusy = false
+        return true
+    }
+
+    /// Adopt a wake date and start or stop the countdown to match.
+    private func setScheduledWake(_ date: Date?) {
+        scheduledWakeDate = date
+        scheduledWakeTimer?.invalidate()
+        scheduledWakeTimer = nil
+        guard date != nil else {
+            scheduledWakeRemaining = ""
+            return
+        }
+        refreshScheduledWakeRemaining()
+        scheduledWakeTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.scheduledWakeTick() }
+        }
+    }
+
+    private func scheduledWakeTick() {
+        guard let date = scheduledWakeDate else { return }
+        // Reaching the deadline means powerd has fired the event (or is about
+        // to). Don't assume it's gone — go and read, which also clears the
+        // countdown once the system has actually let go of it.
+        if Date() >= date {
+            refreshScheduledWake()
+        } else {
+            refreshScheduledWakeRemaining()
+        }
+    }
+
+    private func refreshScheduledWakeRemaining() {
+        guard let date = scheduledWakeDate else { scheduledWakeRemaining = ""; return }
+        scheduledWakeRemaining = ScheduledWake.formatCountdown(
+            ScheduledWake.remaining(until: date, now: Date())
+        )
+    }
+
     // MARK: Battery + safety guard
 
     func tick() {
@@ -830,6 +1055,9 @@ final class AppState: ObservableObject {
         // polling only when we think it's on would structurally miss the case
         // where it was turned on behind our back.
         refreshState()
+        // Cheap (a single unprivileged IOKit read) and it's what notices a wake
+        // that fired, or one set from another copy of the app.
+        refreshScheduledWake()
         if settings.autoEnableWhenCharging {
             reconcile()             // refreshes the battery sample itself
         } else {

--- a/Sources/Lidless/AppState.swift
+++ b/Sources/Lidless/AppState.swift
@@ -125,6 +125,18 @@ final class AppState: ObservableObject {
     private var scheduledWakeTimer: Timer?
     /// Rejects helper replies that a newer schedule/cancel has superseded.
     private var scheduledWakeGeneration = 0
+    /// Same, for the version probe behind the support state — two probes can be
+    /// in flight at once (launch, then a reinstall), and without this the slower
+    /// one lands last and leaves the controls disabled on stale information.
+    private var scheduledWakeSupportGeneration = 0
+    /// The date we last tried to repair the schedule for.
+    ///
+    /// Repair is triggered by reading the schedule and re-triggered by the read
+    /// that follows a failed write, so a repair that keeps failing would drive
+    /// an unbounded write loop. One attempt per state of the world is enough:
+    /// if it didn't work, it won't work by being repeated a thousand times a
+    /// minute, and the leftovers it was tidying are cosmetic.
+    private var attemptedWakeRepairFor: Date?
     private var didWakeObserver: NSObjectProtocol?
     private var clockChangeObserver: NSObjectProtocol?
 
@@ -894,8 +906,10 @@ final class AppState: ObservableObject {
             scheduledWakeSupport = .helperNotInstalled
             return
         }
+        scheduledWakeSupportGeneration += 1
+        let generation = scheduledWakeSupportGeneration
         helper.fetchVersion { [weak self] version in
-            guard let self else { return }
+            guard let self, generation == self.scheduledWakeSupportGeneration else { return }
             self.scheduledWakeSupport = ScheduledWake.supportState(helperInstalled: self.helperInstalled,
                                                                     version: version)
         }
@@ -919,9 +933,11 @@ final class AppState: ObservableObject {
             scheduledWakeUnknown = true
         case .none:
             scheduledWakeUnknown = false
+            attemptedWakeRepairFor = nil
             setScheduledWake(nil)
         case .pending(let date):
             scheduledWakeUnknown = false
+            attemptedWakeRepairFor = nil
             setScheduledWake(date)
         case .repair(let keep):
             scheduledWakeUnknown = false
@@ -929,9 +945,16 @@ final class AppState: ObservableObject {
             // Re-assert rather than reach for a cancel-these-dates call: this
             // ends with exactly one event, at the time now on screen.
             guard scheduledWakeSupport == .supported, !scheduledWakeBusy else { return }
+            // Once per state of the world. A repair that fails re-reads the
+            // schedule, which finds the same mess and would ask for the same
+            // repair — so without this the pair would spin against the helper
+            // for as long as the condition lasted.
+            guard attemptedWakeRepairFor != keep else { return }
+            attemptedWakeRepairFor = keep
             writeScheduledWake(keep, quiet: true)
         case .clear:
             scheduledWakeUnknown = false
+            attemptedWakeRepairFor = nil
             setScheduledWake(nil)
             guard scheduledWakeSupport == .supported, !scheduledWakeBusy else { return }
             let generation = beginScheduledWakeWrite()
@@ -948,6 +971,7 @@ final class AppState: ObservableObject {
     /// Schedule a wake `minutes` from now, replacing any wake already set.
     func scheduleWake(minutes: Int) {
         guard scheduledWakeSupport == .supported else { return }
+        attemptedWakeRepairFor = nil
         writeScheduledWake(ScheduledWake.wakeDate(from: Date(), minutes: minutes), quiet: false)
     }
 
@@ -961,8 +985,13 @@ final class AppState: ObservableObject {
                 // asked for — the system decides what got scheduled.
                 self.scheduledWakeUnknown = false
                 self.setScheduledWake(confirmed)
+            } else if quiet {
+                // A failed repair says nothing the user asked to hear, and
+                // re-reading here is what would close the loop back onto
+                // another repair. The 30-second poll picks it up instead.
+                return
             } else {
-                if !quiet { self.scheduledWakeError = error ?? "Couldn’t set the wake time." }
+                self.scheduledWakeError = error ?? "Couldn’t set the wake time."
                 // The write failed, so we know nothing reliable about the
                 // schedule — it may have landed anyway. Go and look.
                 self.refreshScheduledWake()
@@ -977,6 +1006,7 @@ final class AppState: ObservableObject {
         guard scheduledWakeSupport == .supported else { return }
         let generation = beginScheduledWakeWrite()
         scheduledWakeError = nil
+        attemptedWakeRepairFor = nil
         helper.cancelScheduledWake { [weak self] ok, error in
             guard let self, self.finishScheduledWakeWrite(generation) else { return }
             if ok {
@@ -1022,14 +1052,19 @@ final class AppState: ObservableObject {
 
     private func scheduledWakeTick() {
         guard let date = scheduledWakeDate else { return }
-        // Reaching the deadline means powerd has fired the event (or is about
-        // to). Don't assume it's gone — go and read, which also clears the
-        // countdown once the system has actually let go of it.
-        if Date() >= date {
+        guard Date() < date else {
+            // The moment has arrived, so there is no countdown left to draw and
+            // no reason to keep a one-second timer alive. Stop it before the
+            // read: if the schedule turns out to be unreadable, `.unknown`
+            // leaves the date in place, and a timer still running would then
+            // poll IOKit every second for as long as that lasted. The ordinary
+            // 30-second tick notices the event going away.
+            scheduledWakeTimer?.invalidate()
+            scheduledWakeTimer = nil
             refreshScheduledWake()
-        } else {
-            refreshScheduledWakeRemaining()
+            return
         }
+        refreshScheduledWakeRemaining()
     }
 
     private func refreshScheduledWakeRemaining() {

--- a/Sources/Lidless/HelperManager.swift
+++ b/Sources/Lidless/HelperManager.swift
@@ -101,6 +101,39 @@ final class HelperManager {
         remote({ _ in })?.heartbeat { _ in }
     }
 
+    /// Schedule a one-shot wake. `completion` gets the date the helper read back
+    /// out of the system, or nil plus a message.
+    func scheduleWake(at date: Date, completion: @escaping (Date?, String?) -> Void) {
+        var confirmed: Date?
+        callWithTimeout(completion: { ok, err in completion(ok ? confirmed : nil, err) }) { proxy, done in
+            proxy.scheduleWake(at: date) { date, err in
+                confirmed = date
+                done(date != nil, err)
+            }
+        }
+    }
+
+    func cancelScheduledWake(completion: @escaping (Bool, String?) -> Void) {
+        callWithTimeout(completion: completion) { proxy, done in
+            proxy.cancelScheduledWake { ok, err in done(ok, err) }
+        }
+    }
+
+    /// The helper's version string, or nil if it couldn't be reached.
+    ///
+    /// Nil is "we don't know", not "it's old". A helper that never answers and
+    /// a helper that predates a feature are different problems and the UI says
+    /// different things about them.
+    func fetchVersion(completion: @escaping (String?) -> Void) {
+        var reported: String?
+        callWithTimeout(timeout: 5, completion: { ok, _ in completion(ok ? reported : nil) }) { proxy, done in
+            proxy.version { version in
+                reported = version
+                done(true, nil)
+            }
+        }
+    }
+
     /// True if the daemon answers an XPC call, false if it can't be reached
     /// (connection error or no reply within the timeout). Used to detect a
     /// registered-but-unlaunchable helper after an app update.

--- a/Sources/Lidless/Info.plist
+++ b/Sources/Lidless/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>0.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Sources/Lidless/Info.plist
+++ b/Sources/Lidless/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.1</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Sources/Lidless/MenuContent.swift
+++ b/Sources/Lidless/MenuContent.swift
@@ -94,6 +94,14 @@ struct MenuContent: View {
                 .padding(.horizontal, hInset)
                 .padding(.top, 12)
 
+            ScheduledWakeSection()
+                .padding(.horizontal, hInset)
+                .padding(.top, 12)
+
+            Divider()
+                .padding(.horizontal, hInset)
+                .padding(.top, 12)
+
             FooterActions()
                 .padding(.horizontal, hInset)
                 .padding(.bottom, 14)
@@ -101,7 +109,108 @@ struct MenuContent: View {
         .frame(width: 360)
         // The popover is the moment the user actually looks at the toggle, so
         // it's the moment it most needs to be true.
-        .onAppear { state.refreshState() }
+        .onAppear {
+            state.refreshState()
+            state.refreshScheduledWake()
+        }
+    }
+}
+
+// MARK: - Scheduled wake
+
+/// "Wake my Mac in N minutes" — an action, not a preference, so it lives in the
+/// popover next to the toggle rather than in Settings with the auto-off timer.
+///
+/// The two are easy to confuse and worth keeping apart: auto-off stops keeping
+/// the Mac awake, while this wakes a sleeping Mac up. The countdown here is
+/// held by the system, so it survives quitting the app; auto-off's does not.
+private struct ScheduledWakeSection: View {
+    @EnvironmentObject var state: AppState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            SettingRow(title: "Wake my Mac in") {
+                Menu {
+                    ForEach(ScheduledWake.presetMinutes, id: \.self) { minutes in
+                        Button(ScheduledWake.optionLabel(minutes: minutes)) {
+                            state.scheduleWake(minutes: minutes)
+                        }
+                    }
+                } label: {
+                    Text(state.scheduledWakeDate == nil ? "Choose…" : "Change…")
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+                .disabled(state.scheduledWakeSupport != .supported || state.scheduledWakeBusy)
+            }
+
+            if let date = state.scheduledWakeDate {
+                HStack(spacing: 8) {
+                    // The absolute time leads. It's what the system actually
+                    // holds — an instant, not a duration — and it stays true if
+                    // the clock changes underneath us.
+                    Label(scheduledLabel(date), systemImage: "alarm")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                    Spacer(minLength: 8)
+                    Button("Cancel") { state.cancelScheduledWake() }
+                        .font(.callout)
+                        .disabled(state.scheduledWakeSupport != .supported || state.scheduledWakeBusy)
+                }
+            }
+
+            if let message = unavailableMessage {
+                Text(message)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else if state.scheduledWakeDate != nil {
+                // Say this plainly rather than let the feature look broken. With
+                // the lid shut the Mac may come up as a background wake with the
+                // display still off, and that's the machine's call, not ours.
+                Text("With the lid closed this may be a background wake — the display can stay off.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if state.scheduledWakeUnknown {
+                Label("Couldn’t read the wake schedule.", systemImage: "questionmark.circle.fill")
+                    .font(.callout)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if let error = state.scheduledWakeError {
+                Label(error, systemImage: "info.circle")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.bottom, 2)
+    }
+
+    private func scheduledLabel(_ date: Date) -> String {
+        let time = date.formatted(date: .omitted, time: .shortened)
+        return state.scheduledWakeRemaining.isEmpty
+            ? "Waking at \(time)"
+            : "Waking at \(time) · \(state.scheduledWakeRemaining)"
+    }
+
+    /// Each way of being unavailable gets its own sentence. "Reinstall the
+    /// helper" is the wrong instruction when the daemon simply isn't answering.
+    private var unavailableMessage: String? {
+        switch state.scheduledWakeSupport {
+        case .supported:
+            return nil
+        case .helperNotInstalled:
+            return "Install the background helper in Settings to schedule a wake."
+        case .outdated:
+            return "Reinstall the background helper in Settings to schedule a wake."
+        case .unreachable:
+            return "The background helper isn’t responding, so a wake can’t be scheduled."
+        }
     }
 }
 

--- a/Sources/Lidless/WakeScheduleReader.swift
+++ b/Sources/Lidless/WakeScheduleReader.swift
@@ -1,0 +1,26 @@
+import Foundation
+import IOKit.pwr_mgt
+
+/// Reads the system's scheduled power events.
+///
+/// Unprivileged on purpose. Changing the schedule needs root, but reading it
+/// doesn't — `pmset -g sched` prints the same list without `sudo` — so the app
+/// reads it directly instead of asking the helper. That keeps the display path
+/// off the XPC connection entirely: it can't time out, and it doesn't stop
+/// working against a helper too old to answer the new calls. It's the same
+/// division `PowerManager` already uses for the sleep flag.
+enum WakeScheduleReader {
+
+    /// Every pending power event on the Mac, or nil if the list couldn't be read.
+    ///
+    /// `nil` and `[]` mean different things and callers must keep them apart.
+    /// IOKit documents a NULL return as "there are no scheduled events" — a
+    /// real answer — so that becomes `[]`. `nil` is reserved for a result we
+    /// genuinely couldn't interpret, and must never be shown as "no wake
+    /// scheduled": that's a claim about the machine made from data that says
+    /// nothing, which is the mistake `PowerParsers` exists to avoid.
+    static func copyEvents() -> [[String: Any]]? {
+        guard let raw = IOPMCopyScheduledPowerEvents() else { return [] }
+        return raw.takeRetainedValue() as? [[String: Any]]
+    }
+}

--- a/Sources/Shared/AutoOff.swift
+++ b/Sources/Shared/AutoOff.swift
@@ -6,7 +6,7 @@ import Foundation
 /// in the app — if the app dies the helper watchdog restores sleep anyway.
 public enum AutoOff {
     /// Selectable durations (minutes). `0` means "no auto-off" (stay on until off).
-    public static let presetMinutes = [15, 30, 60, 120, 240]
+    public static let presetMinutes = DurationFormat.standardMinutes
 
     /// When a timer started `minutes` ago from `start` should fire.
     public static func deadline(from start: Date, minutes: Int) -> Date {
@@ -24,20 +24,16 @@ public enum AutoOff {
     }
 
     /// Countdown like `1:05:09` (with hours) or `9:42` (under an hour).
+    ///
+    /// Forwards to `DurationFormat` so this and the scheduled-wake countdown —
+    /// which can be on screen at the same time, in the same popover — can't
+    /// drift apart.
     public static func formatCountdown(_ seconds: TimeInterval) -> String {
-        let total = Int(seconds.rounded())
-        let h = total / 3600
-        let m = (total % 3600) / 60
-        let s = total % 60
-        return h > 0
-            ? String(format: "%d:%02d:%02d", h, m, s)
-            : String(format: "%d:%02d", m, s)
+        DurationFormat.formatCountdown(seconds)
     }
 
     /// Menu label for a duration, e.g. `15 min`, `1 hour`, `2 hours`.
     public static func optionLabel(minutes: Int) -> String {
-        guard minutes % 60 == 0 else { return "\(minutes) min" }
-        let h = minutes / 60
-        return h == 1 ? "1 hour" : "\(h) hours"
+        DurationFormat.optionLabel(minutes: minutes)
     }
 }

--- a/Sources/Shared/DurationFormat.swift
+++ b/Sources/Shared/DurationFormat.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Duration presets and their user-facing formatting, shared by every timed
+/// feature in the app (auto-off, scheduled wake).
+///
+/// This exists as its own namespace rather than living in whichever feature got
+/// written first. Two features rendering a countdown into the same popover must
+/// render it the same way, and the only way to guarantee that without a test
+/// whose whole job is to pin two copies together is to have one copy. A feature
+/// that later needs a genuinely different format should say so by not calling
+/// in here — not by forking these three functions.
+public enum DurationFormat {
+    /// The durations every timed feature offers. A product constant, not a
+    /// per-feature one: a user who learns the menu once should recognise it
+    /// everywhere it appears.
+    public static let standardMinutes = [15, 30, 60, 120, 240]
+
+    /// Countdown like `1:05:09` (with hours) or `9:42` (under an hour).
+    public static func formatCountdown(_ seconds: TimeInterval) -> String {
+        let total = Int(seconds.rounded())
+        let h = total / 3600
+        let m = (total % 3600) / 60
+        let s = total % 60
+        return h > 0
+            ? String(format: "%d:%02d:%02d", h, m, s)
+            : String(format: "%d:%02d", m, s)
+    }
+
+    /// Menu label for a duration, e.g. `15 min`, `1 hour`, `2 hours`.
+    public static func optionLabel(minutes: Int) -> String {
+        guard minutes % 60 == 0 else { return "\(minutes) min" }
+        let h = minutes / 60
+        return h == 1 ? "1 hour" : "\(h) hours"
+    }
+}

--- a/Sources/Shared/HelperProtocol.swift
+++ b/Sources/Shared/HelperProtocol.swift
@@ -36,4 +36,33 @@ public enum LidlessHelper {
 
     /// Helper version string, for a connection sanity check.
     func version(withReply reply: @escaping (String) -> Void)
+
+    /// Schedule a one-shot wake, replacing any wake this app already has.
+    ///
+    /// Replies with the date the helper **read back** out of the system after
+    /// writing it, not the date it was handed: powerd stores these at one-second
+    /// resolution and is the thing that decides what got scheduled. A reply of
+    /// `(date, nil)` therefore means "this is on the machine, verified"; `(nil,
+    /// message)` means it isn't. Contrast `setKeepAwake`, which has no value to
+    /// report and so answers with a plain success flag.
+    ///
+    /// The owner id is **not** a parameter. The helper runs as root and this
+    /// call leads to cancelling power events; letting a caller name which owner
+    /// to act on would hand any client of the Mach service the ability to
+    /// delete power events belonging to macOS or to the user. The helper
+    /// derives its own id from `LIDLESS_MACH_LABEL` instead.
+    func scheduleWake(at date: Date, withReply reply: @escaping (Date?, String?) -> Void)
+
+    /// Remove every wake this app scheduled, and nothing else. Idempotent —
+    /// succeeds when there was nothing to remove.
+    ///
+    /// These two calls are the whole interface, and between them they can
+    /// express every repair the app needs. Leftovers the app spots while
+    /// reconciling — a stale event powerd didn't purge, a duplicate from an
+    /// interrupted write — are cleared by re-asserting the invariant with
+    /// `scheduleWake(at:)` (which sweeps ours before writing) when a wake
+    /// should still be pending, or by `cancelScheduledWake` when none should.
+    /// There is no "cancel these specific dates" call because there is nothing
+    /// it could do that those two can't.
+    func cancelScheduledWake(withReply reply: @escaping (Bool, String?) -> Void)
 }

--- a/Sources/Shared/HelperProtocol.swift
+++ b/Sources/Shared/HelperProtocol.swift
@@ -16,6 +16,43 @@ public enum LidlessHelper {
 
     /// Fallback used only if the app bundle id / env var is unavailable.
     public static let fallbackLabel = "com.nghialuong.lidless.helper"
+
+    /// The app bundle id a helper label was derived from — the inverse of
+    /// `label(appBundleID:)`.
+    public static func appBundleID(fromLabel label: String) -> String {
+        let suffix = ".helper"
+        guard label.hasSuffix(suffix) else { return label }
+        return String(label.dropLast(suffix.count))
+    }
+
+    /// The Apple Developer Team ID both the app and the helper are signed with.
+    public static let teamID = "TAFDRXJZSR"
+
+    /// Code signing requirement the helper demands of anything connecting to it.
+    ///
+    /// The Mach service a `SMAppService` daemon registers is reachable by any
+    /// process on the machine, so without this every local program can ask a
+    /// root daemon to do root things. That was survivable while the only verb
+    /// was keep-awake — it dies with the app, and the watchdog clears it within
+    /// 90 seconds either way — but a scheduled wake outlives the app by design
+    /// and no watchdog touches it, so "any process can set one" is a different
+    /// proposition.
+    ///
+    /// Pins both the identity (this app, not merely something of ours) and the
+    /// team, and requires an Apple-issued chain so a self-signed binary
+    /// claiming the same identifier doesn't match. `anchor apple generic`
+    /// covers Developer ID and Apple Development certificates alike, so a
+    /// locally-built `.dev` app satisfies this the same way a released one does.
+    ///
+    /// Checked per message against the peer's audit token, which is what makes
+    /// it free of the PID-reuse race that a `processIdentifier`-based check has.
+    public static func codeSigningRequirement(appBundleID: String) -> String {
+        """
+        identifier "\(appBundleID)" \
+        and anchor apple generic \
+        and certificate leaf[subject.OU] = "\(teamID)"
+        """
+    }
 }
 
 /// XPC interface implemented by the root helper and called by the app.

--- a/Sources/Shared/ScheduledWake.swift
+++ b/Sources/Shared/ScheduledWake.swift
@@ -189,7 +189,76 @@ public enum ScheduledWake {
         Array(ownedWakeDates(events: events, ownerID: ownerID).filter { $0 > now }.dropFirst())
     }
 
+    // MARK: Reconciling against the system
+
+    /// What the app should do having read the system's power schedule.
+    public enum ReconcileAction: Equatable {
+        /// The schedule couldn't be read. Keep showing whatever was last known
+        /// and say the state is unconfirmed — never "no wake scheduled".
+        case unknown
+        /// We hold no wake, and there's nothing to tidy.
+        case none
+        /// Exactly one wake of ours, in the future. Show it.
+        case pending(Date)
+        /// A wake of ours is pending, but there's debris alongside it —
+        /// duplicates, or an event powerd should have purged. Re-assert the
+        /// invariant by scheduling this date again: `scheduleWake` sweeps ours
+        /// before writing, so one call both cleans up and keeps the right wake.
+        case repair(keep: Date)
+        /// Only debris, nothing pending. Clear ours.
+        case clear
+    }
+
+    /// Decide what to do with the schedule as read.
+    ///
+    /// Takes the optional straight from the reader so the "couldn't read" case
+    /// is handled here rather than at each call site, where it is one `??  []`
+    /// away from being silently reported as an empty schedule.
+    public static func reconcile(events: [[String: Any]]?,
+                                 ownerID: String,
+                                 now: Date,
+                                 grace: TimeInterval = 60) -> ReconcileAction {
+        guard let events else { return .unknown }
+        let pending = pendingWake(events: events, ownerID: ownerID, now: now)
+        let debris = !staleWakeDates(events: events, ownerID: ownerID, now: now, grace: grace).isEmpty
+            || !surplusWakeDates(events: events, ownerID: ownerID, now: now).isEmpty
+        switch (pending, debris) {
+        case (let date?, true):  return .repair(keep: date)
+        case (let date?, false): return .pending(date)
+        case (nil, true):        return .clear
+        case (nil, false):       return .none
+        }
+    }
+
     // MARK: Helper capability
+
+    /// Whether the scheduled-wake controls can be used, and if not, why.
+    ///
+    /// Four states rather than enabled/disabled because the three ways of being
+    /// disabled need different words. Telling someone to reinstall their helper
+    /// when the real problem is that the daemon isn't answering sends them to
+    /// do the wrong thing.
+    public enum SupportState: Equatable {
+        /// No helper installed. Scheduling a wake needs root, and unlike
+        /// keep-awake there is no admin-prompt fallback for it.
+        case helperNotInstalled
+        /// Installed, but it didn't tell us its version — so we don't know.
+        case unreachable
+        /// Installed and answering, but predates these XPC methods.
+        case outdated
+        case supported
+    }
+
+    /// `version` is nil when the helper couldn't be reached at all.
+    public static func supportState(helperInstalled: Bool, version: String?) -> SupportState {
+        guard helperInstalled else { return .helperNotInstalled }
+        guard let version else { return .unreachable }
+        switch helperSupportsScheduledWake(version: version) {
+        case true?:  return .supported
+        case false?: return .outdated
+        case nil:    return .unreachable
+        }
+    }
 
     /// First helper version that implements the scheduled-wake XPC methods.
     public static let minimumHelperVersion = "0.2.0"

--- a/Sources/Shared/ScheduledWake.swift
+++ b/Sources/Shared/ScheduledWake.swift
@@ -99,8 +99,28 @@ public enum ScheduledWake {
     /// comparison, which is a much worse thing to own than a rounding call.
     /// Truncating up front makes verification an exact match.
     public static func wakeDate(from start: Date, minutes: Int) -> Date {
-        let raw = start.addingTimeInterval(TimeInterval(minutes) * 60)
-        return Date(timeIntervalSince1970: raw.timeIntervalSince1970.rounded(.down))
+        wholeSecond(start.addingTimeInterval(TimeInterval(minutes) * 60))
+    }
+
+    /// `date` with any sub-second part dropped.
+    ///
+    /// Applied again inside the helper rather than trusting the caller to have
+    /// done it: the XPC method is an entry point, and a fractional date there
+    /// would schedule fine and then fail its own read-back check, reporting
+    /// failure for a wake that is genuinely on the machine.
+    public static func wholeSecond(_ date: Date) -> Date {
+        Date(timeIntervalSince1970: date.timeIntervalSince1970.rounded(.down))
+    }
+
+    /// Whether a date read back out of powerd is the one we asked for.
+    ///
+    /// Compared at whole-second resolution because that is the resolution the
+    /// system stores. An exact `==` between a `Date` we constructed and one
+    /// bridged back out of a `CFDate` is a stricter claim than the storage can
+    /// support, and failing on it would mean telling the user their wake didn't
+    /// take while the Mac sits there ready to wake.
+    public static func isSameWakeInstant(_ lhs: Date, _ rhs: Date) -> Bool {
+        wholeSecond(lhs) == wholeSecond(rhs)
     }
 
     // MARK: Reading the system schedule
@@ -174,19 +194,23 @@ public enum ScheduledWake {
     /// First helper version that implements the scheduled-wake XPC methods.
     public static let minimumHelperVersion = "0.2.0"
 
-    /// Whether an installed helper can schedule wakes.
+    /// Whether an installed helper can schedule wakes — or nil when its version
+    /// string doesn't say.
     ///
     /// Every user upgrading into this feature has an older helper already
     /// running, and that helper's exported object has no `scheduleWake:`
     /// selector — calling it doesn't fail, it simply never replies, so the app
     /// would sit on `callWithTimeout` for six seconds and then apologise. The
-    /// gate turns that into a disabled control with a "reinstall" affordance.
+    /// gate turns that into a disabled control.
     ///
-    /// Unparseable input is not supported: an unreadable version is not
-    /// evidence of capability, and guessing "yes" here re-creates the exact
-    /// hang the gate exists to prevent.
-    public static func helperSupportsScheduledWake(version: String) -> Bool {
-        compareVersions(version, minimumHelperVersion).map { $0 >= 0 } ?? false
+    /// Three-valued rather than two, for the same reason
+    /// `PowerParsers.sleepDisabled` is: a version we can't read is not a claim
+    /// that the helper is old. Both answers disable the control, but they are
+    /// different situations and deserve different words — "your helper needs
+    /// reinstalling to use this" is a lie when what actually happened is that
+    /// the daemon never answered. Callers decide; this doesn't decide for them.
+    public static func helperSupportsScheduledWake(version: String) -> Bool? {
+        compareVersions(version, minimumHelperVersion).map { $0 >= 0 }
     }
 
     /// Compare dotted numeric versions. Returns nil if either side isn't one.
@@ -200,12 +224,20 @@ public enum ScheduledWake {
         return 0
     }
 
+    /// Split a dotted version into its numbers, or nil if it isn't one.
+    ///
+    /// Each component must be digits and nothing else. `Int(_:)` is more
+    /// permissive than it looks — it accepts a leading sign, so `"0.2.+0"`
+    /// would otherwise parse as `[0, 2, 0]` and read as a helper new enough to
+    /// call, which is precisely the misread this whole gate exists to prevent.
     private static func numericComponents(_ version: String) -> [Int]? {
         let parts = version.split(separator: ".", omittingEmptySubsequences: false)
         guard !parts.isEmpty else { return nil }
         var out: [Int] = []
         for part in parts {
-            guard let n = Int(part), n >= 0 else { return nil }
+            guard !part.isEmpty, part.allSatisfy(\.isASCII), part.allSatisfy(\.isNumber),
+                  let n = Int(part)
+            else { return nil }
             out.append(n)
         }
         return out

--- a/Sources/Shared/ScheduledWake.swift
+++ b/Sources/Shared/ScheduledWake.swift
@@ -1,0 +1,213 @@
+import Foundation
+import IOKit.pwr_mgt
+
+/// Scheduled-wake logic (pure, unit-testable).
+///
+/// The feature asks macOS to wake the Mac at a chosen time and then leave no
+/// trace behind. The scheduling itself is a root-only IOKit call made by the
+/// privileged helper (`IOPMSchedulePowerEvent`); everything *decided* about it
+/// lives here, so it can be tested without root, without a real sleep, and
+/// without touching the machine's power state.
+///
+/// The one fact this whole module is built around: the scheduled events belong
+/// to the system, not to us. `IOPMCopyScheduledPowerEvents()` returns *every*
+/// pending event on the Mac — macOS's own `com.apple.alarm.*` timers, anything
+/// the user set with `pmset schedule`, and ours. So every decision here filters
+/// by owner id *and* event type first. There is no operation in this app that
+/// cancels a power event we didn't create, and `pmset schedule cancelall` — the
+/// obvious shortcut — is exactly the bug that rule exists to prevent.
+public enum ScheduledWake {
+
+    // MARK: Identity
+
+    /// The event type we schedule: `kIOPMAutoWake`, i.e. wake a sleeping Mac.
+    ///
+    /// Deliberately not `kIOPMAutoWakeOrPowerOn` ("wakepoweron"). Shutting the
+    /// Mac down is the user withdrawing every intent they had; a machine that
+    /// powers itself back on afterwards is alarming, not helpful.
+    public static let eventType = kIOPMAutoWake
+
+    /// The suffix that turns an app/helper identifier into our owner id.
+    private static let ownerSuffix = ".wake"
+
+    /// Owner id derived from the helper's Mach service label — the form the
+    /// privileged helper uses, since it knows its label from the environment
+    /// (`LidlessHelper.machLabelEnvKey`) and has no bundle of its own.
+    ///
+    ///     com.nghialuong.lidless.dev.helper  ->  com.nghialuong.lidless.dev.wake
+    ///
+    /// A label without the expected `.helper` suffix still yields a usable id
+    /// rather than a crash or an empty string: an id we can't attribute is
+    /// worse than an ugly one, because filtering falls back to matching
+    /// everything.
+    public static func ownerID(fromMachLabel label: String) -> String {
+        let helperSuffix = ".helper"
+        guard label.hasSuffix(helperSuffix) else { return label + ownerSuffix }
+        return String(label.dropLast(helperSuffix.count)) + ownerSuffix
+    }
+
+    /// Owner id derived from the app's bundle id — the form the app uses when
+    /// it reads the schedule back. Must agree with `ownerID(fromMachLabel:)`
+    /// for the same install, or the app would read a schedule it can't see and
+    /// report "nothing scheduled" while an event of ours sits in powerd.
+    ///
+    ///     com.nghialuong.lidless.dev  ->  com.nghialuong.lidless.dev.wake
+    public static func ownerID(appBundleID: String) -> String {
+        appBundleID + ownerSuffix
+    }
+
+    // MARK: Presets
+
+    /// Selectable durations for "wake me in…".
+    ///
+    /// Debug builds get a one-minute option. Verifying this feature by hand
+    /// means putting the Mac to sleep and waiting for it to wake up, and doing
+    /// that on a 15-minute floor makes the check expensive enough that it stops
+    /// getting done. It is `#if DEBUG` because a one-minute wake is a test
+    /// affordance, not a thing to ship.
+    public static var presetMinutes: [Int] {
+        #if DEBUG
+        return [1] + DurationFormat.standardMinutes
+        #else
+        return DurationFormat.standardMinutes
+        #endif
+    }
+
+    /// Menu label for a duration, e.g. `15 min`, `1 hour`.
+    public static func optionLabel(minutes: Int) -> String {
+        DurationFormat.optionLabel(minutes: minutes)
+    }
+
+    /// Countdown like `12:41`, shown next to the absolute wake time.
+    public static func formatCountdown(_ seconds: TimeInterval) -> String {
+        DurationFormat.formatCountdown(seconds)
+    }
+
+    /// Seconds until `date` (never negative).
+    public static func remaining(until date: Date, now: Date) -> TimeInterval {
+        max(0, date.timeIntervalSince(now))
+    }
+
+    // MARK: Scheduling
+
+    /// When a wake requested `minutes` from `start` should fire, truncated to a
+    /// whole second.
+    ///
+    /// powerd stores these at one-second resolution, so an un-truncated date
+    /// would come back from `IOPMCopyScheduledPowerEvents()` slightly different
+    /// from the one we sent — and the read-back check would then need a fuzzy
+    /// comparison, which is a much worse thing to own than a rounding call.
+    /// Truncating up front makes verification an exact match.
+    public static func wakeDate(from start: Date, minutes: Int) -> Date {
+        let raw = start.addingTimeInterval(TimeInterval(minutes) * 60)
+        return Date(timeIntervalSince1970: raw.timeIntervalSince1970.rounded(.down))
+    }
+
+    // MARK: Reading the system schedule
+
+    /// Wake dates belonging to `ownerID`, from the dictionaries that
+    /// `IOPMCopyScheduledPowerEvents()` hands back.
+    ///
+    /// Keys are IOKit's (`IOPMKeys.h`): `time` (a Date), `scheduledby` (the
+    /// owner string we passed when scheduling), `eventtype` (`"wake"` here).
+    ///
+    /// An entry missing a key, or holding an unexpected type, is skipped rather
+    /// than guessed at — the same rule `PowerParsers` follows. A malformed
+    /// entry defaulted into "ours" would put a foreign power event on the list
+    /// of things we're willing to cancel, and there is no data here worth that.
+    /// Sorted ascending, so callers can reason about "the next one" directly.
+    public static func ownedWakeDates(events: [[String: Any]], ownerID: String) -> [Date] {
+        events.compactMap { event -> Date? in
+            guard let owner = event[kIOPMPowerEventAppNameKey] as? String, owner == ownerID,
+                  let type = event[kIOPMPowerEventTypeKey] as? String, type == eventType,
+                  let date = event[kIOPMPowerEventTimeKey] as? Date
+            else { return nil }
+            return date
+        }
+        .sorted()
+    }
+
+    /// The wake that will actually happen next: the earliest of ours still in
+    /// the future, or nil if we have none pending.
+    ///
+    /// Earliest, not latest. If duplicates ever exist, powerd fires the soonest
+    /// one — showing any other time would be telling the user something about
+    /// their Mac that isn't true. (Duplicates are also cleaned up; see
+    /// `surplusWakeDates`. This decides what to *display* while that happens.)
+    ///
+    /// Strictly in the future: an event whose moment has arrived has fired, and
+    /// a countdown at or below zero is not a thing we should ever render.
+    public static func pendingWake(events: [[String: Any]], ownerID: String, now: Date) -> Date? {
+        ownedWakeDates(events: events, ownerID: ownerID).first { $0 > now }
+    }
+
+    /// Leftovers of ours worth cleaning up: events far enough past that powerd
+    /// should already have purged them.
+    ///
+    /// The grace window matters. powerd removes a one-shot event once it fires,
+    /// but "fires" and "is gone from the list" are not the same instant, and a
+    /// reconcile that runs in between would otherwise ask the helper to cancel
+    /// an event the system is in the middle of handling. Inside the window we
+    /// neither display the event nor touch it — it is on its way out.
+    public static func staleWakeDates(events: [[String: Any]],
+                                      ownerID: String,
+                                      now: Date,
+                                      grace: TimeInterval = 60) -> [Date] {
+        ownedWakeDates(events: events, ownerID: ownerID)
+            .filter { $0 <= now.addingTimeInterval(-grace) }
+    }
+
+    /// Future events of ours beyond the first — i.e. the ones that shouldn't
+    /// exist, since we hold at most one wake at a time. Cancelled on sight.
+    ///
+    /// Reaching this state means an earlier write was interrupted between its
+    /// cancel and its schedule. Rare, but the cost of not handling it is the
+    /// Mac waking at a time nothing in the UI ever mentioned.
+    public static func surplusWakeDates(events: [[String: Any]],
+                                        ownerID: String,
+                                        now: Date) -> [Date] {
+        Array(ownedWakeDates(events: events, ownerID: ownerID).filter { $0 > now }.dropFirst())
+    }
+
+    // MARK: Helper capability
+
+    /// First helper version that implements the scheduled-wake XPC methods.
+    public static let minimumHelperVersion = "0.2.0"
+
+    /// Whether an installed helper can schedule wakes.
+    ///
+    /// Every user upgrading into this feature has an older helper already
+    /// running, and that helper's exported object has no `scheduleWake:`
+    /// selector — calling it doesn't fail, it simply never replies, so the app
+    /// would sit on `callWithTimeout` for six seconds and then apologise. The
+    /// gate turns that into a disabled control with a "reinstall" affordance.
+    ///
+    /// Unparseable input is not supported: an unreadable version is not
+    /// evidence of capability, and guessing "yes" here re-creates the exact
+    /// hang the gate exists to prevent.
+    public static func helperSupportsScheduledWake(version: String) -> Bool {
+        compareVersions(version, minimumHelperVersion).map { $0 >= 0 } ?? false
+    }
+
+    /// Compare dotted numeric versions. Returns nil if either side isn't one.
+    private static func compareVersions(_ lhs: String, _ rhs: String) -> Int? {
+        guard let l = numericComponents(lhs), let r = numericComponents(rhs) else { return nil }
+        for i in 0..<max(l.count, r.count) {
+            let a = i < l.count ? l[i] : 0
+            let b = i < r.count ? r[i] : 0
+            if a != b { return a < b ? -1 : 1 }
+        }
+        return 0
+    }
+
+    private static func numericComponents(_ version: String) -> [Int]? {
+        let parts = version.split(separator: ".", omittingEmptySubsequences: false)
+        guard !parts.isEmpty else { return nil }
+        var out: [Int] = []
+        for part in parts {
+            guard let n = Int(part), n >= 0 else { return nil }
+            out.append(n)
+        }
+        return out
+    }
+}

--- a/Tests/LidlessTests/ScheduledWakeTests.swift
+++ b/Tests/LidlessTests/ScheduledWakeTests.swift
@@ -406,6 +406,46 @@ final class ScheduledWakeTests: XCTestCase {
         XCTAssertNil(ScheduledWake.helperSupportsScheduledWake(version: "٠.٢.٠"))
     }
 
+    // MARK: Code signing requirement — what stands between the app and anyone else
+
+    func testAppBundleIDIsInverseOfLabel() {
+        for bundleID in ["com.nghialuong.lidless", "com.nghialuong.lidless.dev"] {
+            let label = LidlessHelper.label(appBundleID: bundleID)
+            XCTAssertEqual(LidlessHelper.appBundleID(fromLabel: label), bundleID)
+        }
+    }
+
+    func testAppBundleIDLeavesUnexpectedLabelAlone() {
+        XCTAssertEqual(LidlessHelper.appBundleID(fromLabel: "com.example.thing"),
+                       "com.example.thing")
+    }
+
+    /// All three clauses have to be there. Dropping the identifier lets any of
+    /// our binaries in; dropping the anchor lets a self-signed impostor claim
+    /// the identifier; dropping the team lets someone else's Apple-signed app in.
+    func testCodeSigningRequirementPinsIdentityAnchorAndTeam() {
+        let requirement = LidlessHelper.codeSigningRequirement(appBundleID: "com.nghialuong.lidless")
+        XCTAssertTrue(requirement.contains("identifier \"com.nghialuong.lidless\""))
+        XCTAssertTrue(requirement.contains("anchor apple generic"))
+        XCTAssertTrue(requirement.contains("certificate leaf[subject.OU] = \"\(LidlessHelper.teamID)\""))
+    }
+
+    /// The `.dev` build and the release build must not satisfy each other's
+    /// requirement — that separation is the whole reason they have distinct ids.
+    func testCodeSigningRequirementDiffersBetweenDebugAndReleaseIdentifiers() {
+        XCTAssertNotEqual(LidlessHelper.codeSigningRequirement(appBundleID: "com.nghialuong.lidless"),
+                          LidlessHelper.codeSigningRequirement(appBundleID: "com.nghialuong.lidless.dev"))
+    }
+
+    /// A malformed requirement throws an Objective-C exception at the point it
+    /// is set, which in the helper means the daemon dies on every connection.
+    /// Keep it to one line with no stray newlines.
+    func testCodeSigningRequirementIsASingleLine() {
+        let requirement = LidlessHelper.codeSigningRequirement(appBundleID: "com.nghialuong.lidless")
+        XCTAssertFalse(requirement.contains("\n"))
+        XCTAssertFalse(requirement.isEmpty)
+    }
+
     // MARK: Shared presets and formatting
 
     func testEventTypeIsWakeNotWakeOrPowerOn() {

--- a/Tests/LidlessTests/ScheduledWakeTests.swift
+++ b/Tests/LidlessTests/ScheduledWakeTests.swift
@@ -268,6 +268,100 @@ final class ScheduledWakeTests: XCTestCase {
         XCTAssertTrue(ScheduledWake.surplusWakeDates(events: events, ownerID: owner, now: t0).isEmpty)
     }
 
+    // MARK: reconcile — what the app does with what it read
+
+    /// An unreadable schedule must not turn into "nothing scheduled". This is
+    /// the whole reason the reader returns an optional.
+    func testReconcileUnknownWhenEventsCouldNotBeRead() {
+        XCTAssertEqual(ScheduledWake.reconcile(events: nil, ownerID: owner, now: t0), .unknown)
+    }
+
+    func testReconcileNoneForEmptySchedule() {
+        XCTAssertEqual(ScheduledWake.reconcile(events: [], ownerID: owner, now: t0), .none)
+    }
+
+    /// A schedule full of other people's events is, for us, an empty one — and
+    /// crucially not something to "repair".
+    func testReconcileNoneWhenOnlyForeignEventsExist() {
+        XCTAssertEqual(ScheduledWake.reconcile(events: systemEvents(now: t0),
+                                               ownerID: owner, now: t0), .none)
+    }
+
+    func testReconcilePendingForSingleFutureEvent() {
+        let date = t0.addingTimeInterval(900)
+        let events = systemEvents(now: t0) + [event(at: date, owner: owner)]
+        XCTAssertEqual(ScheduledWake.reconcile(events: events, ownerID: owner, now: t0),
+                       .pending(date))
+    }
+
+    func testReconcileRepairsDuplicatesKeepingEarliest() {
+        let sooner = t0.addingTimeInterval(600)
+        let later = t0.addingTimeInterval(1800)
+        let events = [event(at: later, owner: owner), event(at: sooner, owner: owner)]
+        XCTAssertEqual(ScheduledWake.reconcile(events: events, ownerID: owner, now: t0),
+                       .repair(keep: sooner))
+    }
+
+    /// Debris alongside a good event must not cost us the good event.
+    func testReconcileRepairsWhenStaleSitsBesidePending() {
+        let pending = t0.addingTimeInterval(900)
+        let events = [event(at: t0.addingTimeInterval(-300), owner: owner),
+                      event(at: pending, owner: owner)]
+        XCTAssertEqual(ScheduledWake.reconcile(events: events, ownerID: owner, now: t0),
+                       .repair(keep: pending))
+    }
+
+    func testReconcileClearsWhenOnlyStaleRemains() {
+        let events = [event(at: t0.addingTimeInterval(-300), owner: owner)]
+        XCTAssertEqual(ScheduledWake.reconcile(events: events, ownerID: owner, now: t0), .clear)
+    }
+
+    /// A just-fired event is powerd's business for another moment. Neither show
+    /// it nor race the system to delete it.
+    func testReconcileNoneForJustFiredEventInsideGrace() {
+        let events = [event(at: t0.addingTimeInterval(-30), owner: owner)]
+        XCTAssertEqual(ScheduledWake.reconcile(events: events, ownerID: owner, now: t0), .none)
+    }
+
+    /// Debris belonging to macOS is not debris we clean up.
+    func testReconcileIgnoresForeignStaleEvents() {
+        let events = [event(at: t0.addingTimeInterval(-9999),
+                            owner: "com.apple.alarm.user-invisible-something")]
+        XCTAssertEqual(ScheduledWake.reconcile(events: events, ownerID: owner, now: t0), .none)
+    }
+
+    // MARK: supportState — three different ways to be unavailable
+
+    func testSupportStateHelperNotInstalled() {
+        XCTAssertEqual(ScheduledWake.supportState(helperInstalled: false, version: "0.2.0"),
+                       .helperNotInstalled)
+        XCTAssertEqual(ScheduledWake.supportState(helperInstalled: false, version: nil),
+                       .helperNotInstalled)
+    }
+
+    func testSupportStateSupportedForCurrentHelper() {
+        XCTAssertEqual(ScheduledWake.supportState(helperInstalled: true, version: "0.2.0"),
+                       .supported)
+        XCTAssertEqual(ScheduledWake.supportState(helperInstalled: true, version: "1.4.0"),
+                       .supported)
+    }
+
+    func testSupportStateOutdatedForOlderHelper() {
+        XCTAssertEqual(ScheduledWake.supportState(helperInstalled: true, version: "0.1.0"),
+                       .outdated)
+    }
+
+    /// A helper that didn't answer is not an old helper, and telling the user
+    /// to reinstall would send them to fix the wrong thing.
+    func testSupportStateUnreachableWhenVersionMissingOrUnreadable() {
+        XCTAssertEqual(ScheduledWake.supportState(helperInstalled: true, version: nil),
+                       .unreachable)
+        XCTAssertEqual(ScheduledWake.supportState(helperInstalled: true, version: "garbage"),
+                       .unreachable)
+        XCTAssertEqual(ScheduledWake.supportState(helperInstalled: true, version: ""),
+                       .unreachable)
+    }
+
     // MARK: Helper capability gate
 
     func testHelperSupportsScheduledWakeAcceptsEqualAndNewer() {

--- a/Tests/LidlessTests/ScheduledWakeTests.swift
+++ b/Tests/LidlessTests/ScheduledWakeTests.swift
@@ -87,6 +87,27 @@ final class ScheduledWakeTests: XCTestCase {
         XCTAssertEqual(result.timeIntervalSince1970, 1_000_060, accuracy: 0.0001)
     }
 
+    func testWholeSecondDropsSubsecondPart() {
+        XCTAssertEqual(ScheduledWake.wholeSecond(Date(timeIntervalSince1970: 1_000_000.999)),
+                       Date(timeIntervalSince1970: 1_000_000))
+        XCTAssertEqual(ScheduledWake.wholeSecond(Date(timeIntervalSince1970: 1_000_000)),
+                       Date(timeIntervalSince1970: 1_000_000))
+    }
+
+    /// A wake that powerd rounded to the second is the wake we asked for.
+    /// Insisting on exact equality would report failure for an event that is
+    /// genuinely sitting on the machine, ready to fire.
+    func testSameWakeInstantIgnoresSubsecondDifference() {
+        let asked = Date(timeIntervalSince1970: 1_000_000.5)
+        let stored = Date(timeIntervalSince1970: 1_000_000)
+        XCTAssertTrue(ScheduledWake.isSameWakeInstant(asked, stored))
+    }
+
+    func testSameWakeInstantRejectsDifferentSeconds() {
+        XCTAssertFalse(ScheduledWake.isSameWakeInstant(Date(timeIntervalSince1970: 1_000_000),
+                                                       Date(timeIntervalSince1970: 1_000_001)))
+    }
+
     // MARK: Filtering — the promise not to touch anyone else's events
 
     func testOwnedWakeDatesIgnoresForeignOwners() {
@@ -250,26 +271,45 @@ final class ScheduledWakeTests: XCTestCase {
     // MARK: Helper capability gate
 
     func testHelperSupportsScheduledWakeAcceptsEqualAndNewer() {
-        XCTAssertTrue(ScheduledWake.helperSupportsScheduledWake(version: "0.2.0"))
-        XCTAssertTrue(ScheduledWake.helperSupportsScheduledWake(version: "0.2.1"))
-        XCTAssertTrue(ScheduledWake.helperSupportsScheduledWake(version: "0.3"))
-        XCTAssertTrue(ScheduledWake.helperSupportsScheduledWake(version: "1.0.0"))
+        XCTAssertEqual(ScheduledWake.helperSupportsScheduledWake(version: "0.2.0"), true)
+        XCTAssertEqual(ScheduledWake.helperSupportsScheduledWake(version: "0.2.1"), true)
+        XCTAssertEqual(ScheduledWake.helperSupportsScheduledWake(version: "0.3"), true)
+        XCTAssertEqual(ScheduledWake.helperSupportsScheduledWake(version: "1.0.0"), true)
+        XCTAssertEqual(ScheduledWake.helperSupportsScheduledWake(version: "0.10.0"), true)
     }
 
     func testHelperSupportsScheduledWakeRejectsOlder() {
-        XCTAssertFalse(ScheduledWake.helperSupportsScheduledWake(version: "0.1.0"))
-        XCTAssertFalse(ScheduledWake.helperSupportsScheduledWake(version: "0.1.9"))
-        XCTAssertFalse(ScheduledWake.helperSupportsScheduledWake(version: "0"))
+        XCTAssertEqual(ScheduledWake.helperSupportsScheduledWake(version: "0.1.0"), false)
+        XCTAssertEqual(ScheduledWake.helperSupportsScheduledWake(version: "0.1.9"), false)
+        XCTAssertEqual(ScheduledWake.helperSupportsScheduledWake(version: "0"), false)
     }
 
-    /// An unreadable version is not evidence the helper can do this. Guessing
-    /// "yes" recreates the six-second hang the gate exists to prevent.
-    func testHelperSupportsScheduledWakeRejectsUnparseableInput() {
-        XCTAssertFalse(ScheduledWake.helperSupportsScheduledWake(version: ""))
-        XCTAssertFalse(ScheduledWake.helperSupportsScheduledWake(version: "abc"))
-        XCTAssertFalse(ScheduledWake.helperSupportsScheduledWake(version: "0.2.0-beta"))
-        XCTAssertFalse(ScheduledWake.helperSupportsScheduledWake(version: "0..2"))
-        XCTAssertFalse(ScheduledWake.helperSupportsScheduledWake(version: "-1.0.0"))
+    /// An unreadable version is not a claim that the helper is old — it's an
+    /// absence of information, and the caller needs to be able to tell the two
+    /// apart to say something true to the user.
+    func testHelperSupportsScheduledWakeIsUnknownForUnparseableInput() {
+        XCTAssertNil(ScheduledWake.helperSupportsScheduledWake(version: ""))
+        XCTAssertNil(ScheduledWake.helperSupportsScheduledWake(version: "abc"))
+        XCTAssertNil(ScheduledWake.helperSupportsScheduledWake(version: "0.2.0-beta"))
+        XCTAssertNil(ScheduledWake.helperSupportsScheduledWake(version: "0..2"))
+        XCTAssertNil(ScheduledWake.helperSupportsScheduledWake(version: "-1.0.0"))
+        XCTAssertNil(ScheduledWake.helperSupportsScheduledWake(version: " 0.2.0"))
+    }
+
+    /// `Int(_:)` accepts a leading sign, so a component like `"+0"` parses to a
+    /// perfectly ordinary number. Left unchecked, `"0.2.+0"` would read as a
+    /// helper new enough to call — the exact misread this gate prevents.
+    func testHelperSupportsScheduledWakeRejectsSignedComponents() {
+        XCTAssertNil(ScheduledWake.helperSupportsScheduledWake(version: "0.2.+0"))
+        XCTAssertNil(ScheduledWake.helperSupportsScheduledWake(version: "+0.2.0"))
+        XCTAssertNil(ScheduledWake.helperSupportsScheduledWake(version: "0.+2.0"))
+        XCTAssertNil(ScheduledWake.helperSupportsScheduledWake(version: "0.2.-0"))
+    }
+
+    /// Non-ASCII digits are numbers to `Character.isNumber` and to `Int(_:)`,
+    /// so they need excluding too — a version is ASCII or it isn't a version.
+    func testHelperSupportsScheduledWakeRejectsNonASCIIDigits() {
+        XCTAssertNil(ScheduledWake.helperSupportsScheduledWake(version: "٠.٢.٠"))
     }
 
     // MARK: Shared presets and formatting

--- a/Tests/LidlessTests/ScheduledWakeTests.swift
+++ b/Tests/LidlessTests/ScheduledWakeTests.swift
@@ -1,0 +1,307 @@
+import XCTest
+import IOKit.pwr_mgt
+
+/// Tests for the pure scheduled-wake logic.
+///
+/// The fixtures deliberately mirror what a real Mac returns: the two
+/// `com.apple.alarm.user-invisible-*` events below are copied from actual
+/// `pmset -g sched` output on a machine with nothing unusual configured. They
+/// are here because the single worst outcome this feature could have is
+/// cancelling a power event that isn't ours, and a test using only our own
+/// events would never catch it.
+final class ScheduledWakeTests: XCTestCase {
+
+    // MARK: Fixtures
+
+    private let owner = "com.nghialuong.lidless.dev.wake"
+
+    private func event(at date: Date,
+                       owner: String,
+                       type: String = kIOPMAutoWake) -> [String: Any] {
+        [
+            kIOPMPowerEventTimeKey: date,
+            kIOPMPowerEventAppNameKey: owner,
+            kIOPMPowerEventTypeKey: type
+        ]
+    }
+
+    /// Events macOS itself schedules — observed verbatim on a real machine.
+    private func systemEvents(now: Date) -> [[String: Any]] {
+        [
+            event(at: now.addingTimeInterval(600),
+                  owner: "com.apple.alarm.user-invisible-com.apple.calaccessd.travelEngine.periodicRefreshTimer"),
+            event(at: now.addingTimeInterval(60_000),
+                  owner: "com.apple.alarm.user-invisible-com.apple.osanalytics.hardhighengagementtimer")
+        ]
+    }
+
+    private let t0 = Date(timeIntervalSince1970: 1_000_000)
+
+    // MARK: Owner id
+
+    func testOwnerIDFromMachLabelReplacesHelperSuffix() {
+        XCTAssertEqual(ScheduledWake.ownerID(fromMachLabel: "com.nghialuong.lidless.dev.helper"),
+                       "com.nghialuong.lidless.dev.wake")
+        XCTAssertEqual(ScheduledWake.ownerID(fromMachLabel: "com.nghialuong.lidless.helper"),
+                       "com.nghialuong.lidless.wake")
+    }
+
+    /// An unexpected label must still produce a distinctive id. Returning an
+    /// empty string would make the owner filter match nothing (feature dead) or,
+    /// worse, match loosely.
+    func testOwnerIDFromMachLabelWithoutHelperSuffixAppends() {
+        XCTAssertEqual(ScheduledWake.ownerID(fromMachLabel: "com.example.thing"),
+                       "com.example.thing.wake")
+        XCTAssertEqual(ScheduledWake.ownerID(fromMachLabel: ""), ".wake")
+    }
+
+    /// The helper derives the id from its Mach label; the app derives it from
+    /// its bundle id. If those two ever disagree, the app reads a schedule it
+    /// cannot see and reports "no wake scheduled" while one is pending.
+    func testOwnerIDFromBundleIDMatchesMachLabelDerivation() {
+        let bundleID = "com.nghialuong.lidless.dev"
+        let machLabel = LidlessHelper.label(appBundleID: bundleID)
+        XCTAssertEqual(ScheduledWake.ownerID(appBundleID: bundleID),
+                       ScheduledWake.ownerID(fromMachLabel: machLabel))
+    }
+
+    func testOwnerIDMatchesReleaseAndDebugSeparately() {
+        XCTAssertNotEqual(ScheduledWake.ownerID(appBundleID: "com.nghialuong.lidless"),
+                          ScheduledWake.ownerID(appBundleID: "com.nghialuong.lidless.dev"))
+    }
+
+    // MARK: Wake date
+
+    func testWakeDateAddsRequestedMinutes() {
+        XCTAssertEqual(ScheduledWake.wakeDate(from: t0, minutes: 15),
+                       t0.addingTimeInterval(900))
+        XCTAssertEqual(ScheduledWake.wakeDate(from: t0, minutes: 240),
+                       t0.addingTimeInterval(14_400))
+    }
+
+    /// powerd stores whole seconds; truncating up front is what lets the
+    /// read-back check be an exact comparison instead of a fuzzy one.
+    func testWakeDateTruncatesToWholeSecond() {
+        let fractional = Date(timeIntervalSince1970: 1_000_000.75)
+        let result = ScheduledWake.wakeDate(from: fractional, minutes: 1)
+        XCTAssertEqual(result.timeIntervalSince1970, 1_000_060, accuracy: 0.0001)
+    }
+
+    // MARK: Filtering — the promise not to touch anyone else's events
+
+    func testOwnedWakeDatesIgnoresForeignOwners() {
+        let ours = t0.addingTimeInterval(900)
+        let events = systemEvents(now: t0) + [event(at: ours, owner: owner)]
+        XCTAssertEqual(ScheduledWake.ownedWakeDates(events: events, ownerID: owner), [ours])
+    }
+
+    func testOwnedWakeDatesReturnsNothingWhenOnlyForeignEventsExist() {
+        XCTAssertTrue(ScheduledWake.ownedWakeDates(events: systemEvents(now: t0),
+                                                   ownerID: owner).isEmpty)
+    }
+
+    /// A sleep or power-on event carrying our owner id is not a wake we
+    /// scheduled, and must not be counted as one — nor cancelled as one.
+    func testOwnedWakeDatesIgnoresNonWakeEventTypes() {
+        let events = [
+            event(at: t0.addingTimeInterval(900), owner: owner, type: "sleep"),
+            event(at: t0.addingTimeInterval(1800), owner: owner, type: kIOPMAutoPowerOn),
+            event(at: t0.addingTimeInterval(2700), owner: owner, type: kIOPMAutoWakeOrPowerOn)
+        ]
+        XCTAssertTrue(ScheduledWake.ownedWakeDates(events: events, ownerID: owner).isEmpty)
+    }
+
+    func testOwnedWakeDatesSkipsEntryMissingKeys() {
+        let events: [[String: Any]] = [
+            [kIOPMPowerEventAppNameKey: owner, kIOPMPowerEventTypeKey: kIOPMAutoWake],  // no time
+            [kIOPMPowerEventTimeKey: t0, kIOPMPowerEventTypeKey: kIOPMAutoWake],        // no owner
+            [kIOPMPowerEventTimeKey: t0, kIOPMPowerEventAppNameKey: owner],             // no type
+            [:]
+        ]
+        XCTAssertTrue(ScheduledWake.ownedWakeDates(events: events, ownerID: owner).isEmpty)
+    }
+
+    /// Same rule `PowerParsers` follows: data of an unexpected shape says
+    /// nothing, so it must not be defaulted into "this one is ours".
+    func testOwnedWakeDatesSkipsEntryWithWrongTypes() {
+        let events: [[String: Any]] = [
+            [kIOPMPowerEventTimeKey: "12/25/26 09:00:00",
+             kIOPMPowerEventAppNameKey: owner,
+             kIOPMPowerEventTypeKey: kIOPMAutoWake],
+            [kIOPMPowerEventTimeKey: t0,
+             kIOPMPowerEventAppNameKey: 42,
+             kIOPMPowerEventTypeKey: kIOPMAutoWake],
+            [kIOPMPowerEventTimeKey: t0,
+             kIOPMPowerEventAppNameKey: owner,
+             kIOPMPowerEventTypeKey: 7]
+        ]
+        XCTAssertTrue(ScheduledWake.ownedWakeDates(events: events, ownerID: owner).isEmpty)
+    }
+
+    func testOwnedWakeDatesReturnsAscendingOrder() {
+        let later = t0.addingTimeInterval(1800)
+        let sooner = t0.addingTimeInterval(600)
+        let events = [event(at: later, owner: owner), event(at: sooner, owner: owner)]
+        XCTAssertEqual(ScheduledWake.ownedWakeDates(events: events, ownerID: owner),
+                       [sooner, later])
+    }
+
+    func testOwnedWakeDatesEmptyForEmptyInput() {
+        XCTAssertTrue(ScheduledWake.ownedWakeDates(events: [], ownerID: owner).isEmpty)
+    }
+
+    // MARK: pendingWake — what the machine will actually do next
+
+    func testPendingWakeReturnsEarliestFutureNotLatest() {
+        let sooner = t0.addingTimeInterval(600)
+        let later = t0.addingTimeInterval(1800)
+        let events = [event(at: later, owner: owner), event(at: sooner, owner: owner)]
+        XCTAssertEqual(ScheduledWake.pendingWake(events: events, ownerID: owner, now: t0), sooner)
+    }
+
+    func testPendingWakeIgnoresPastEventsAndPicksNextFuture() {
+        let past = t0.addingTimeInterval(-600)
+        let future = t0.addingTimeInterval(600)
+        let events = [event(at: past, owner: owner), event(at: future, owner: owner)]
+        XCTAssertEqual(ScheduledWake.pendingWake(events: events, ownerID: owner, now: t0), future)
+    }
+
+    func testPendingWakeNilWhenAllEventsPast() {
+        let events = [event(at: t0.addingTimeInterval(-600), owner: owner)]
+        XCTAssertNil(ScheduledWake.pendingWake(events: events, ownerID: owner, now: t0))
+    }
+
+    /// The moment has arrived, so the event has fired. A countdown of exactly
+    /// zero is not something to render.
+    func testPendingWakeAtExactlyNowIsNotPending() {
+        let events = [event(at: t0, owner: owner)]
+        XCTAssertNil(ScheduledWake.pendingWake(events: events, ownerID: owner, now: t0))
+    }
+
+    func testPendingWakeNilWhenOnlyForeignEventsPending() {
+        XCTAssertNil(ScheduledWake.pendingWake(events: systemEvents(now: t0),
+                                               ownerID: owner, now: t0))
+    }
+
+    // MARK: staleWakeDates — cleanup, with a grace window
+
+    /// Just-fired events belong to powerd for a moment; cancelling one mid-purge
+    /// is a race we simply decline to enter.
+    func testStaleWakeDatesExcludesWithinGraceWindow() {
+        let justFired = t0.addingTimeInterval(-30)
+        let events = [event(at: justFired, owner: owner)]
+        XCTAssertTrue(ScheduledWake.staleWakeDates(events: events, ownerID: owner, now: t0).isEmpty)
+    }
+
+    func testStaleWakeDatesIncludesBeyondGrace() {
+        let old = t0.addingTimeInterval(-90)
+        let events = [event(at: old, owner: owner)]
+        XCTAssertEqual(ScheduledWake.staleWakeDates(events: events, ownerID: owner, now: t0), [old])
+    }
+
+    func testStaleWakeDatesBoundaryIsInclusiveAtExactlyGrace() {
+        let exactly = t0.addingTimeInterval(-60)
+        let events = [event(at: exactly, owner: owner)]
+        XCTAssertEqual(ScheduledWake.staleWakeDates(events: events, ownerID: owner, now: t0),
+                       [exactly])
+    }
+
+    func testStaleWakeDatesExcludesFutureEvents() {
+        let events = [event(at: t0.addingTimeInterval(900), owner: owner)]
+        XCTAssertTrue(ScheduledWake.staleWakeDates(events: events, ownerID: owner, now: t0).isEmpty)
+    }
+
+    func testStaleWakeDatesNeverIncludesForeignEvents() {
+        let ancient = t0.addingTimeInterval(-9999)
+        let events = [
+            event(at: ancient, owner: "com.apple.alarm.user-invisible-something"),
+            event(at: ancient, owner: "pmset")
+        ]
+        XCTAssertTrue(ScheduledWake.staleWakeDates(events: events, ownerID: owner, now: t0).isEmpty)
+    }
+
+    // MARK: surplusWakeDates — duplicates get cancelled, earliest survives
+
+    func testSurplusWakeDatesReturnsAllButEarliest() {
+        let a = t0.addingTimeInterval(600)
+        let b = t0.addingTimeInterval(1200)
+        let c = t0.addingTimeInterval(1800)
+        let events = [event(at: c, owner: owner), event(at: a, owner: owner), event(at: b, owner: owner)]
+        XCTAssertEqual(ScheduledWake.surplusWakeDates(events: events, ownerID: owner, now: t0), [b, c])
+    }
+
+    func testSurplusWakeDatesEmptyForSingleEvent() {
+        let events = [event(at: t0.addingTimeInterval(600), owner: owner)]
+        XCTAssertTrue(ScheduledWake.surplusWakeDates(events: events, ownerID: owner, now: t0).isEmpty)
+    }
+
+    func testSurplusWakeDatesIgnoresPastEvents() {
+        let past = t0.addingTimeInterval(-600)
+        let future = t0.addingTimeInterval(600)
+        let events = [event(at: past, owner: owner), event(at: future, owner: owner)]
+        XCTAssertTrue(ScheduledWake.surplusWakeDates(events: events, ownerID: owner, now: t0).isEmpty)
+    }
+
+    func testSurplusWakeDatesNeverIncludesForeignEvents() {
+        let events = systemEvents(now: t0) + [event(at: t0.addingTimeInterval(60), owner: owner)]
+        XCTAssertTrue(ScheduledWake.surplusWakeDates(events: events, ownerID: owner, now: t0).isEmpty)
+    }
+
+    // MARK: Helper capability gate
+
+    func testHelperSupportsScheduledWakeAcceptsEqualAndNewer() {
+        XCTAssertTrue(ScheduledWake.helperSupportsScheduledWake(version: "0.2.0"))
+        XCTAssertTrue(ScheduledWake.helperSupportsScheduledWake(version: "0.2.1"))
+        XCTAssertTrue(ScheduledWake.helperSupportsScheduledWake(version: "0.3"))
+        XCTAssertTrue(ScheduledWake.helperSupportsScheduledWake(version: "1.0.0"))
+    }
+
+    func testHelperSupportsScheduledWakeRejectsOlder() {
+        XCTAssertFalse(ScheduledWake.helperSupportsScheduledWake(version: "0.1.0"))
+        XCTAssertFalse(ScheduledWake.helperSupportsScheduledWake(version: "0.1.9"))
+        XCTAssertFalse(ScheduledWake.helperSupportsScheduledWake(version: "0"))
+    }
+
+    /// An unreadable version is not evidence the helper can do this. Guessing
+    /// "yes" recreates the six-second hang the gate exists to prevent.
+    func testHelperSupportsScheduledWakeRejectsUnparseableInput() {
+        XCTAssertFalse(ScheduledWake.helperSupportsScheduledWake(version: ""))
+        XCTAssertFalse(ScheduledWake.helperSupportsScheduledWake(version: "abc"))
+        XCTAssertFalse(ScheduledWake.helperSupportsScheduledWake(version: "0.2.0-beta"))
+        XCTAssertFalse(ScheduledWake.helperSupportsScheduledWake(version: "0..2"))
+        XCTAssertFalse(ScheduledWake.helperSupportsScheduledWake(version: "-1.0.0"))
+    }
+
+    // MARK: Shared presets and formatting
+
+    func testEventTypeIsWakeNotWakeOrPowerOn() {
+        XCTAssertEqual(ScheduledWake.eventType, "wake")
+        XCTAssertNotEqual(ScheduledWake.eventType, kIOPMAutoWakeOrPowerOn)
+    }
+
+    func testPresetsContainTheStandardDurations() {
+        for minutes in DurationFormat.standardMinutes {
+            XCTAssertTrue(ScheduledWake.presetMinutes.contains(minutes),
+                          "missing preset \(minutes)")
+        }
+    }
+
+    /// Release builds must not offer the one-minute test affordance.
+    func testOneMinutePresetIsDebugOnly() {
+        #if DEBUG
+        XCTAssertEqual(ScheduledWake.presetMinutes.first, 1)
+        #else
+        XCTAssertFalse(ScheduledWake.presetMinutes.contains(1))
+        #endif
+    }
+
+    func testFormattingMatchesAutoOff() {
+        XCTAssertEqual(ScheduledWake.formatCountdown(3909), AutoOff.formatCountdown(3909))
+        XCTAssertEqual(ScheduledWake.optionLabel(minutes: 60), AutoOff.optionLabel(minutes: 60))
+    }
+
+    func testRemainingClampsToZero() {
+        XCTAssertEqual(ScheduledWake.remaining(until: t0.addingTimeInterval(-10), now: t0), 0)
+        XCTAssertEqual(ScheduledWake.remaining(until: t0.addingTimeInterval(90), now: t0), 90)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -58,6 +58,10 @@ targets:
           destination: executables
       - package: Sparkle
         product: Sparkle
+      # Scheduled wake reads the system power schedule via
+      # IOPMCopyScheduledPowerEvents. Declared rather than left to Swift's
+      # implicit auto-link: this file is the spec that gets reviewed.
+      - sdk: IOKit.framework
     postBuildScripts:
       # Generate the privileged helper's LaunchDaemon plist from the app's bundle
       # id so the Release and `.dev` builds register isolated daemons. Runs before
@@ -113,6 +117,10 @@ targets:
           PRODUCT_BUNDLE_IDENTIFIER: com.nghialuong.lidless.dev.helper
         Release:
           PRODUCT_BUNDLE_IDENTIFIER: com.nghialuong.lidless.helper
+    dependencies:
+      # IOPMSchedulePowerEvent / IOPMCancelScheduledPowerEvent — the root-only
+      # half of scheduled wake.
+      - sdk: IOKit.framework
 
   LidlessTests:
     type: bundle.unit-test
@@ -128,6 +136,9 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.nghialuong.lidlessTests
         GENERATE_INFOPLIST_FILE: YES
+    dependencies:
+      # Sources/Shared imports IOKit.pwr_mgt for the power-event key constants.
+      - sdk: IOKit.framework
 
 schemes:
   Lidless:


### PR DESCRIPTION
Hẹn giờ đánh thức máy: chọn "wake in 15 min" trong popover, Mac tự thức sau 15 phút, rồi lịch đó tự biến mất.

## Cách hoạt động

`IOPMSchedulePowerEvent(date, ownerID, kIOPMAutoWake)` chạy trong root helper có sẵn. Phần "auto disable" không cần code: event one-shot được powerd tiêu thụ sau khi fire — app chỉ đọc lại và cập nhật UI.

**powerd là source of truth.** Không có deadline nào được lưu vào UserDefaults. Đó là lý do countdown dựng lại được sau khi quit app hoặc reboot, và cũng là lý do quit app **không** huỷ lịch — như quit app đồng hồ không xoá alarm.

Ghi cần root nên đi qua XPC; đọc thì không (`pmset -g sched` chạy được không sudo) nên app đọc `IOPMCopyScheduledPowerEvents()` trực tiếp. Giữ đường hiển thị hoàn toàn ngoài XPC: không timeout được, và vẫn chạy với helper cũ chưa có method mới.

## Không đụng lịch của người khác

`IOPMCopyScheduledPowerEvents()` trả về **mọi** power event của máy — máy nào cũng đang có sẵn vài cái `com.apple.alarm.*` của macOS, cộng lịch `pmset schedule` user tự đặt. Nên mọi quyết định đều lọc theo owner id **và** event type trước. Không có đường nào trong app gọi `IOPMCancelScheduledPowerEvent` với event không phải của mình, và không bao giờ dùng `pmset schedule cancelall`. Fixture trong test lấy từ output thật của máy để ràng buộc điều này.

Owner id do helper **tự derive** từ `LIDLESS_MACH_LABEL`, không nhận qua XPC — nếu nhận thì caller có thể bảo root xoá event của bất kỳ ai.

## Siết bảo mật kèm theo

Mach service mà một `SMAppService` daemon đăng ký thì process nào trên máy cũng kết nối được, và listener trước giờ nhận mọi connection. Chấp nhận được khi verb duy nhất là keep-awake (chết theo app, watchdog gỡ trong 90s), nhưng scheduled wake sống lâu hơn app và không watchdog nào đụng tới — nên để mở là chuyện khác.

Thêm `setCodeSigningRequirement` (public từ macOS 13, đúng bằng deployment target, xác thực theo audit token nên không dính PID-reuse race). Requirement pin identity + Apple anchor + Team ID.

Đã verify bằng build ký thật: Debug và Release mỗi bản thoả requirement của mình, và Debug app **trượt** requirement của Release. Requirement string cũng được `csreq` parse, với một control âm cố tình sai bị từ chối.

Fix này bảo vệ luôn cả `setKeepAwake` đang có.

## Test

117 → 175 test, 0 failure, 0 warning mới.

Mọi quyết định nằm trong `Sources/Shared/ScheduledWake.swift` (thuần, không cần root, không cần máy ngủ): lọc theo owner, earliest-future, ranh giới stale/grace, dọn duplicate, gate version helper. Adapter IOKit cố tình giữ mỏng vì không test được.

## ⚠️ Cần bạn test tay — chưa cái nào tự động verify được

```bash
pmset -g sched                       # baseline, ghi lại
sudo pmset schedule wake "12/25/26 09:00:00"    # lịch "của user" để chứng minh không bị đụng

# hẹn 1 phút trong app (preset 1 min chỉ có ở DEBUG build)
pmset -g sched   # phải thấy event by 'com.nghialuong.lidless.dev.wake'
                 # và lịch 12/25 + com.apple.alarm.* còn NGUYÊN

# hẹn lại 2 phút → chỉ đúng 1 event .dev.wake, không có event mồ côi
# bấm Cancel → chỉ event .dev.wake biến mất
# quit app khi đang có lịch → lịch VẪN CÒN (cố ý)

sudo pmset sleepnow               # đợi máy tự thức
pmset -g log | grep -Ei 'wake from|darkwake' | tail -5
pmset -g sched                    # event .dev.wake đã TỰ biến mất

sudo pmset schedule cancel wake "12/25/26 09:00:00"   # dọn, KHÔNG dùng cancelall
```

**Quan trọng nhất — test với nắp đóng.** Đo xem: có wake không, DarkWake hay full wake, màn có sáng không, máy ngủ lại sau bao lâu. Lid-closed là lý do tồn tại của app này, và v1 cố ý không hứa interactive wake — UI nói thẳng màn có thể vẫn tắt. Nếu kết quả là "bấm nút rồi không quan sát được gì" thì đó là quyết định product cần bàn, không phải bug im lặng.

Cũng nên test với helper cũ (bản release 0.1.2 đã cài) → section phải disabled, **không** timeout lặp lại, keep-awake vẫn chạy bình thường.

## NIT chưa sửa (Fable nêu, không chặn merge)

- `clearOwnedWakes` phía helper không có grace 60s như phía app — hẹn lịch mới trong ~60s sau khi lịch cũ vừa fire có thể báo lỗi oan.
- `scheduleWake` không validate date nằm ở tương lai.
- `copyEvents` bị duplicate giữa `WakeScheduleReader` và `WakeScheduler`.

Plan gốc + transcript debate: `debates/2026-08-06-scheduled-wake/`. Audit đầy đủ: `git notes --ref=forge show forge/scheduled-wake`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
