### PR TITLE
Require the peer be our app before handing it root

### DIFF
--- a/Sources/Helper/HelperService.swift
+++ b/Sources/Helper/HelperService.swift
@@ -3,8 +3,27 @@ import Foundation
 final class HelperListenerDelegate: NSObject, NSXPCListenerDelegate {
     private let service = HelperService()
 
+    /// The app this helper belongs to, recovered from the label launchd started
+    /// us with. The Debug and Release builds run separate daemons under separate
+    /// labels, so each ends up demanding its own app and not the other's.
+    private let appBundleID = LidlessHelper.appBundleID(
+        fromLabel: ProcessInfo.processInfo.environment[LidlessHelper.machLabelEnvKey]
+            ?? LidlessHelper.fallbackLabel
+    )
+
     func listener(_ listener: NSXPCListener,
                   shouldAcceptNewConnection newConnection: NSXPCConnection) -> Bool {
+        // Require the peer be our app before handing it an object that runs as
+        // root. Without this, the check amounts to "did something on this Mac
+        // connect", which every process passes.
+        //
+        // `setCodeSigningRequirement` validates against the peer's audit token
+        // on each message, so it has none of the PID-reuse race that inspecting
+        // `processIdentifier` would. It must be set before `resume()`, and it is
+        // an XPC error to set it twice — hence here, once, on a fresh connection.
+        newConnection.setCodeSigningRequirement(
+            LidlessHelper.codeSigningRequirement(appBundleID: appBundleID)
+        )
         newConnection.exportedInterface = NSXPCInterface(with: LidlessHelperProtocol.self)
         newConnection.exportedObject = service
         newConnection.resume()

--- a/Sources/Shared/HelperProtocol.swift
+++ b/Sources/Shared/HelperProtocol.swift
@@ -16,6 +16,41 @@ public enum LidlessHelper {
 
     /// Fallback used only if the app bundle id / env var is unavailable.
     public static let fallbackLabel = "com.nghialuong.lidless.helper"
+
+    /// The app bundle id a helper label was derived from — the inverse of
+    /// `label(appBundleID:)`.
+    public static func appBundleID(fromLabel label: String) -> String {
+        let suffix = ".helper"
+        guard label.hasSuffix(suffix) else { return label }
+        return String(label.dropLast(suffix.count))
+    }
+
+    /// The Apple Developer Team ID the app and helper are signed with.
+    public static let teamID = "TAFDRXJZSR"
+
+    /// Code signing requirement the helper demands of anything connecting to it.
+    ///
+    /// The Mach service an `SMAppService` daemon registers is reachable by every
+    /// process on the machine, and the listener used to accept all of them. So
+    /// any program a user ran could ask a root daemon to hold their Mac awake
+    /// indefinitely — on a laptop, in a bag, that is a heat and battery problem
+    /// they'd have no way to attribute.
+    ///
+    /// The three clauses cover each other. `identifier` alone would admit any
+    /// binary claiming the name; `anchor apple generic` alone would admit every
+    /// Apple-signed app on the Mac; the team check alone would admit anything
+    /// else we ever ship. Together they mean this app, signed by us.
+    ///
+    /// `anchor apple generic` is satisfied by Developer ID and Apple Development
+    /// certificates alike, so a locally-built `.dev` app passes exactly as a
+    /// released one does.
+    public static func codeSigningRequirement(appBundleID: String) -> String {
+        """
+        identifier "\(appBundleID)" \
+        and anchor apple generic \
+        and certificate leaf[subject.OU] = "\(teamID)"
+        """
+    }
 }
 
 /// XPC interface implemented by the root helper and called by the app.

--- a/Tests/LidlessTests/HelperIdentityTests.swift
+++ b/Tests/LidlessTests/HelperIdentityTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+
+/// Tests for the helper's identity and the code signing requirement it demands
+/// of anything connecting to it.
+final class HelperIdentityTests: XCTestCase {
+
+    func testAppBundleIDIsInverseOfLabel() {
+        for bundleID in ["com.nghialuong.lidless", "com.nghialuong.lidless.dev"] {
+            let label = LidlessHelper.label(appBundleID: bundleID)
+            XCTAssertEqual(LidlessHelper.appBundleID(fromLabel: label), bundleID)
+        }
+    }
+
+    /// The fallback label has to round-trip too — it's what the requirement is
+    /// built from when the environment variable is missing, and a wrong answer
+    /// there would have the helper demand an app that doesn't exist, locking out
+    /// the real one.
+    func testAppBundleIDHandlesFallbackLabel() {
+        XCTAssertEqual(LidlessHelper.appBundleID(fromLabel: LidlessHelper.fallbackLabel),
+                       "com.nghialuong.lidless")
+    }
+
+    func testAppBundleIDLeavesUnexpectedLabelAlone() {
+        XCTAssertEqual(LidlessHelper.appBundleID(fromLabel: "com.example.thing"),
+                       "com.example.thing")
+        XCTAssertEqual(LidlessHelper.appBundleID(fromLabel: ""), "")
+    }
+
+    /// Each clause closes a hole the other two leave open: identity alone admits
+    /// an impostor using the name, the anchor alone admits every Apple-signed
+    /// app, the team alone admits anything else we ship.
+    func testRequirementPinsIdentityAnchorAndTeam() {
+        let requirement = LidlessHelper.codeSigningRequirement(appBundleID: "com.nghialuong.lidless")
+        XCTAssertTrue(requirement.contains("identifier \"com.nghialuong.lidless\""))
+        XCTAssertTrue(requirement.contains("anchor apple generic"))
+        XCTAssertTrue(requirement.contains("certificate leaf[subject.OU] = \"\(LidlessHelper.teamID)\""))
+    }
+
+    /// The `.dev` and release builds must not satisfy each other's requirement —
+    /// keeping their daemons isolated is the whole point of the separate ids.
+    func testRequirementDiffersBetweenDebugAndReleaseIdentifiers() {
+        XCTAssertNotEqual(
+            LidlessHelper.codeSigningRequirement(appBundleID: "com.nghialuong.lidless"),
+            LidlessHelper.codeSigningRequirement(appBundleID: "com.nghialuong.lidless.dev")
+        )
+    }
+
+    /// A malformed requirement throws an Objective-C exception where it's set,
+    /// which in the helper means dying on every incoming connection. Keep it to
+    /// one line with nothing stray in it.
+    func testRequirementIsASingleNonEmptyLine() {
+        let requirement = LidlessHelper.codeSigningRequirement(appBundleID: "com.nghialuong.lidless")
+        XCTAssertFalse(requirement.contains("\n"))
+        XCTAssertFalse(requirement.isEmpty)
+    }
+
+    /// The requirement the daemon builds must match the app that will call it.
+    /// These are derived on opposite sides of the XPC boundary from different
+    /// inputs — the helper from its launchd label, the app from its bundle id —
+    /// so a drift between them locks the app out of its own helper.
+    func testRequirementFromLabelMatchesRequirementFromBundleID() {
+        for bundleID in ["com.nghialuong.lidless", "com.nghialuong.lidless.dev"] {
+            let label = LidlessHelper.label(appBundleID: bundleID)
+            XCTAssertEqual(
+                LidlessHelper.codeSigningRequirement(appBundleID: LidlessHelper.appBundleID(fromLabel: label)),
+                LidlessHelper.codeSigningRequirement(appBundleID: bundleID)
+            )
+        }
+    }
+}


### PR DESCRIPTION
Mach service mà một `SMAppService` daemon đăng ký thì **mọi process trên máy đều kết nối được**, và listener đang nhận hết. Check hiện tại tương đương "có thứ gì đó trên máy này kết nối à" — thứ gì cũng qua. Nghĩa là bất kỳ chương trình nào user chạy đều có thể bảo root daemon giữ máy thức vô thời hạn. Với laptop trong túi, đó là vấn đề nhiệt và pin mà user không có cách nào truy ra nguyên nhân.

## Fix

`setCodeSigningRequirement` xác thực theo **audit token** của peer trên từng message, nên không dính PID-reuse race như cách soi `processIdentifier`. Nó public từ **macOS 13** — đúng bằng deployment target của app, phủ trọn dải OS được hỗ trợ.

Ba mệnh đề trong requirement bịt lỗ cho nhau:

| Mệnh đề | Nếu chỉ có mình nó |
|---|---|
| `identifier` | Kẻ mạo danh chỉ cần đặt trùng tên |
| `anchor apple generic` | Mọi app ký bởi Apple trên máy đều lọt |
| `certificate leaf[subject.OU]` | Mọi thứ khác chúng ta từng ship đều lọt |

`anchor apple generic` thoả cả Developer ID lẫn Apple Development cert, nên dev build local pass y như bản release.

Helper tự derive app bundle id từ label launchd của chính nó, nên daemon Debug đòi app `.dev` còn daemon Release đòi app release — giữ nguyên sự cô lập giữa hai bản.

## Verify

```
$ echo '<requirement>' | csreq -r- -b /tmp/req.bin        => OK
$ echo 'identifier "x" and bogus_clause' | csreq -r- ...  => syntax error   (control âm hoạt động)

# build ký thật:
Debug app (Apple Development, Team TAFDRXJZSR)
  -R='identifier "com.nghialuong.lidless.dev" ...'  => MATCHES
  -R='identifier "com.nghialuong.lidless" ...'      => FAILS      (.dev không giả được release)
Release app (Developer ID)
  -R='identifier "com.nghialuong.lidless" ...'      => MATCHES
```

Ngoài ra đã chạy app thật với fix này: `fetchVersion` đi trọn vòng XPC xuyên qua requirement mới và helper trả lời bình thường — tức là app thật **không** bị chính requirement của mình chặn. Đây là rủi ro đáng lo nhất của thay đổi này (requirement sai thì keep-awake hỏng với mọi user), nên tôi verify bằng quan sát chứ không suy luận.

117 → 124 test, 0 failure, 0 warning mới.

## ⚠️ Vẫn nên test tay trước khi merge

Test tự động không chứng minh được vòng XPC với helper **đã cài + đã approve** qua đường release thật. Cần: cài helper, bật/tắt keep-awake vài lần, xác nhận không hiện "The background helper isn't responding".

Nếu requirement sai thì lỗi là **loud** chứ không im lặng — connection bị invalidate, `callWithTimeout` báo lỗi ngay — nên sẽ thấy được, không âm thầm hỏng.

Tách ra từ PR #26 (đã đóng vì tôi hiểu sai yêu cầu tính năng). Lỗ hổng này có thật và độc lập với tính năng đó.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
