### PR TITLE
Keep the Mac awake for a chosen stretch, in one gesture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,15 @@
 name: CI
 
 on:
+  # Scoped to main so a branch that already has a pull request doesn't build
+  # twice for the same commit — once for the push, once for the PR.
   push:
+    branches: [main]
   pull_request:
 
 jobs:
   build-test:
     runs-on: macos-15
-    if:     github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
 

--- a/Sources/Lidless/AppState.swift
+++ b/Sources/Lidless/AppState.swift
@@ -332,12 +332,34 @@ final class AppState: ObservableObject {
         BatteryInfo(percent: batteryPercent, onAC: batteryOnAC)
     }
 
-    /// Change the auto-off duration. Re-arms (or cancels) the live timer when
-    /// keep-awake is currently on.
-    func setAutoOffMinutes(_ minutes: Int) {
+    /// "Keep awake for N minutes" — the whole gesture, in one call.
+    ///
+    /// Turns keep-awake on when it isn't already, because that is plainly what
+    /// asking for fifteen minutes of it means. Making someone flip the switch
+    /// first and *then* set a duration is making them do the bookkeeping.
+    ///
+    /// Note the ordering when it has to enable: the duration is persisted first,
+    /// then the write goes out, and the countdown is armed from the write's
+    /// confirmation (via `updateAutoOff(for:)`). So if the safety policy refuses
+    /// — flat battery, running hot — no timer is left counting down for a state
+    /// the Mac never entered.
+    func keepAwakeFor(minutes: Int) {
+        let request = AutoOff.request(minutes: minutes,
+                                      isEnabled: isEnabled,
+                                      autoModeOn: settings.autoEnableWhenCharging)
+        guard request != .ignoredInAutoMode else { return }
         autoOffMinutes = minutes
         store.saveAutoOffMinutes(minutes)
-        if isEnabled { armAutoOff() } else { cancelAutoOff() }
+        switch request {
+        case .ignoredInAutoMode:
+            break
+        case .cancelTimer:
+            cancelAutoOff()
+        case .armTimer:
+            armAutoOff()
+        case .enableThenArmTimer:
+            setEnabled(true, origin: .user)
+        }
     }
 
     func setLaunchAtLogin(_ enabled: Bool) {

--- a/Sources/Lidless/MenuBarExtraPanel.swift
+++ b/Sources/Lidless/MenuBarExtraPanel.swift
@@ -26,9 +26,30 @@ enum MenuBarExtraPanel {
         className.contains("NSStatusBarWindow")
     }
 
+    /// Which window `dismiss` would fall back to closing, given the class names
+    /// of the app's windows in order — or nil when none of them is the panel.
+    ///
+    /// Pulled out as a pure function so the selection can be tested against
+    /// arbitrary window lists. The alternative is standing up real `NSWindow`s
+    /// in a test, which drags in window-server availability and AppKit's
+    /// release-on-close lifecycle — neither of which has anything to do with
+    /// the thing worth checking, which is that only the panel is ever picked.
+    static func panelWindowIndex(classNames: [String]) -> Int? {
+        classNames.firstIndex { isPanelWindow(className: $0) }
+    }
+
+    /// Class names of the status-bar windows to try, in order.
+    static func statusBarWindowIndices(classNames: [String]) -> [Int] {
+        classNames.indices.filter { isStatusBarWindow(className: classNames[$0]) }
+    }
+
     /// Close the popover if it's open. No-op when it isn't.
     static func dismiss() {
-        for window in NSApp.windows where isStatusBarWindow(className: window.className) {
+        dismiss(windows: NSApp.windows)
+    }
+
+    static func dismiss(windows: [NSWindow]) {
+        for window in windows where isStatusBarWindow(className: window.className) {
             // `statusItem` is a private property. Ask before reading it: a bare
             // value(forKey:) raises an uncatchable ObjC exception if it's gone.
             guard window.responds(to: NSSelectorFromString("statusItem")),
@@ -44,6 +65,8 @@ enum MenuBarExtraPanel {
 
         // If that shape ever changes, close the panel directly. The icon stays
         // highlighted until the next click, which beats a popover that won't go.
-        NSApp.windows.first { isPanelWindow(className: $0.className) }?.close()
+        if let index = panelWindowIndex(classNames: windows.map(\.className)) {
+            windows[index].close()
+        }
     }
 }

--- a/Sources/Lidless/MenuContent.swift
+++ b/Sources/Lidless/MenuContent.swift
@@ -32,6 +32,9 @@ struct MenuContent: View {
             PrimaryToggleRow()
                 .padding(.horizontal, hInset)
 
+            KeepAwakeDurationRow()
+                .padding(.horizontal, hInset)
+
             if !state.autoWarningReasons.isEmpty {
                 AutoDisabledWarning(reasons: state.autoWarningReasons)
                     .padding(.horizontal, hInset)
@@ -164,6 +167,58 @@ private struct PrimaryToggleRow: View {
             .controlSize(.regular)
             .tint(.accentColor)
         }
+    }
+}
+
+// MARK: - Keep-awake duration
+
+/// "Keep awake for 15 minutes" as a single gesture: picking a duration turns
+/// keep-awake on and starts the countdown that turns it back off.
+///
+/// Sits directly under the toggle because it modifies it — this is how long the
+/// switch above stays on, not a setting that lives somewhere else.
+private struct KeepAwakeDurationRow: View {
+    @EnvironmentObject var state: AppState
+
+    private var autoMode: Bool { state.settings.autoEnableWhenCharging }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            SettingRow(title: "Keep awake for", minHeight: 32) {
+                // A Menu of buttons rather than a Picker: a Picker's binding only
+                // fires when the value *changes*, so after a timer had elapsed,
+                // choosing the same duration again would do nothing at all —
+                // exactly when someone wants another fifteen minutes.
+                Menu {
+                    Button(AutoOff.durationLabel(minutes: 0)) { state.keepAwakeFor(minutes: 0) }
+                    ForEach(AutoOff.presetMinutes, id: \.self) { minutes in
+                        Button(AutoOff.optionLabel(minutes: minutes)) {
+                            state.keepAwakeFor(minutes: minutes)
+                        }
+                    }
+                } label: {
+                    Text(AutoOff.durationLabel(minutes: state.autoOffMinutes))
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+                .disabled(autoMode)
+            }
+
+            if !state.autoOffRemaining.isEmpty {
+                Label("Turning off in \(state.autoOffRemaining)", systemImage: "timer")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            } else if autoMode {
+                // Auto mode decides activation itself, so a countdown would
+                // disarm the feature behind its back. Say so rather than leaving
+                // a control that looks live and does nothing.
+                Text("Not used while “Automatically enable when charging” is on.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.bottom, 8)
     }
 }
 

--- a/Sources/Lidless/SettingsView.swift
+++ b/Sources/Lidless/SettingsView.swift
@@ -44,30 +44,12 @@ struct SettingsView: View {
                 Text("Background helper")
             }
 
-            Section("Auto-off timer") {
-                Picker("Turn off after", selection: Binding(
-                    get: { state.autoOffMinutes },
-                    set: { state.setAutoOffMinutes($0) }
-                )) {
-                    Text("Never").tag(0)
-                    ForEach(AutoOff.presetMinutes, id: \.self) { m in
-                        Text(AutoOff.optionLabel(minutes: m)).tag(m)
-                    }
-                }
-                if state.isEnabled, !state.autoOffRemaining.isEmpty {
-                    LabeledContent("Turning off in", value: state.autoOffRemaining)
-                        .foregroundStyle(.secondary)
-                }
-                // Auto mode decides activation on its own, so a countdown would
-                // disarm the feature out from under it. Say so rather than letting
-                // the picker look live while doing nothing.
-                if state.settings.autoEnableWhenCharging {
-                    Text("Not used while “Automatically enable when charging” is on.")
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .disabled(state.settings.autoEnableWhenCharging)
+            // The auto-off timer used to live here as a preference — set a
+            // duration, then separately remember to flip the switch. It's now a
+            // "Keep awake for…" control in the popover next to the toggle it
+            // governs, where choosing a duration also turns keep-awake on. One
+            // concept, one place; a second entry point here would only be a
+            // second thing to keep in step.
 
             Section("Updates") {
                 Toggle("Check for updates automatically", isOn: $updater.automaticallyChecksForUpdates)

--- a/Sources/Shared/AutoOff.swift
+++ b/Sources/Shared/AutoOff.swift
@@ -8,6 +8,41 @@ public enum AutoOff {
     /// Selectable durations (minutes). `0` means "no auto-off" (stay on until off).
     public static let presetMinutes = [15, 30, 60, 120, 240]
 
+    /// What picking a duration should do.
+    ///
+    /// "Keep awake for 15 minutes" is one intention, and asking someone to
+    /// perform it as two steps — flip the switch, then find the timer — is
+    /// asking them to do the app's bookkeeping. So choosing a duration turns
+    /// keep-awake on if it isn't already.
+    public enum Request: Equatable {
+        /// Auto mode decides activation from power and safety; a countdown would
+        /// disarm the feature out from under it, so the control does nothing
+        /// while that's on. (The UI disables it and says why rather than letting
+        /// it look live.)
+        case ignoredInAutoMode
+        /// "No limit" — drop any countdown. Deliberately does *not* turn
+        /// keep-awake off: removing the time limit is not the same request as
+        /// stopping, and the master toggle is right there for stopping.
+        case cancelTimer
+        /// Already on, so there's nothing to switch — just (re)start the count.
+        case armTimer(minutes: Int)
+        /// Off, and a duration was asked for. Turn it on; the countdown starts
+        /// when the write is confirmed, so a refusal on safety grounds leaves no
+        /// timer running for a state that never happened.
+        case enableThenArmTimer(minutes: Int)
+    }
+
+    public static func request(minutes: Int, isEnabled: Bool, autoModeOn: Bool) -> Request {
+        if autoModeOn { return .ignoredInAutoMode }
+        guard minutes > 0 else { return .cancelTimer }
+        return isEnabled ? .armTimer(minutes: minutes) : .enableThenArmTimer(minutes: minutes)
+    }
+
+    /// Label for the duration control, e.g. `No limit`, `15 min`, `1 hour`.
+    public static func durationLabel(minutes: Int) -> String {
+        minutes > 0 ? optionLabel(minutes: minutes) : "No limit"
+    }
+
     /// When a timer started `minutes` ago from `start` should fire.
     public static func deadline(from start: Date, minutes: Int) -> Date {
         start.addingTimeInterval(TimeInterval(minutes) * 60)

--- a/Tests/LidlessTests/MenuBarExtraPanelTests.swift
+++ b/Tests/LidlessTests/MenuBarExtraPanelTests.swift
@@ -19,16 +19,48 @@ final class MenuBarExtraPanelTests: XCTestCase {
         XCTAssertFalse(MenuBarExtraPanel.isStatusBarWindow(className: "SwiftUI.MenuBarExtraWindow"))
     }
 
-    /// There's no menu bar extra in the test runner, so this exercises the path
-    /// where nothing matches — it must fall through quietly, not trap. The same
-    /// path runs in the app if these private classes are ever renamed.
-    func testDismissIsHarmlessWithNoMenuBarExtraPresent() {
-        let unrelated = NSWindow(contentRect: .zero, styleMask: [.titled], backing: .buffered, defer: true)
-        unrelated.orderFront(nil)
-        defer { unrelated.close() }
+    // MARK: Which window gets closed
 
-        MenuBarExtraPanel.dismiss()
+    // These test the selection rather than the closing. An earlier version stood
+    // up a real `NSWindow` and asserted it was still visible afterwards, which
+    // failed on a headless CI runner for reasons that had nothing to do with the
+    // behaviour: `orderFront(nil)` can't show a window with no window server.
+    // Replacing the visibility check with a close-recording `NSWindow` subclass
+    // was worse — swallowing `close()` breaks AppKit's release-on-close
+    // lifecycle and crashes XCTest's memory checker. The thing actually worth
+    // pinning down is that only the panel is ever picked, and that needs no
+    // windows at all.
 
-        XCTAssertTrue(unrelated.isVisible, "dismiss() must not touch unrelated windows")
+    func testPicksThePanelWindowToClose() {
+        let windows = ["NSWindow", "NSStatusBarWindow", "SwiftUI.MenuBarExtraWindow", "NSWindow"]
+        XCTAssertEqual(MenuBarExtraPanel.panelWindowIndex(classNames: windows), 2)
+    }
+
+    /// The point of the old "harmless" test, without the windows: ordinary app
+    /// windows are never candidates for closing.
+    func testPicksNothingWhenNoPanelIsPresent() {
+        XCTAssertNil(MenuBarExtraPanel.panelWindowIndex(
+            classNames: ["NSWindow", "NSStatusBarWindow", "NSToolbarWindow", "_NSFullScreenWindow"]
+        ))
+        XCTAssertNil(MenuBarExtraPanel.panelWindowIndex(classNames: []))
+    }
+
+    func testPicksTheFirstPanelWhenSeveralMatch() {
+        let windows = ["NSWindow", "SwiftUI.MenuBarExtraWindow", "SwiftUI.MenuBarExtraWindow"]
+        XCTAssertEqual(MenuBarExtraPanel.panelWindowIndex(classNames: windows), 1)
+    }
+
+    /// One status bar window per screen when "Displays have Separate Spaces" is
+    /// on, so the walk has to consider all of them and no one else.
+    func testFindsEveryStatusBarWindowAndNothingElse() {
+        let windows = ["NSWindow", "NSStatusBarWindow", "SwiftUI.MenuBarExtraWindow", "NSStatusBarWindow"]
+        XCTAssertEqual(MenuBarExtraPanel.statusBarWindowIndices(classNames: windows), [1, 3])
+        XCTAssertEqual(MenuBarExtraPanel.statusBarWindowIndices(classNames: ["NSWindow"]), [])
+    }
+
+    /// The no-match path must fall through quietly rather than trap — the same
+    /// path the app takes if these private classes are ever renamed.
+    func testDismissWithNoWindowsIsHarmless() {
+        MenuBarExtraPanel.dismiss(windows: [])
     }
 }

--- a/Tests/LidlessTests/SharedLogicTests.swift
+++ b/Tests/LidlessTests/SharedLogicTests.swift
@@ -145,6 +145,55 @@ final class SharedLogicTests: XCTestCase {
         XCTAssertEqual(AutoOff.formatCountdown(0), "0:00")
     }
 
+    // MARK: AutoOff.request — "keep awake for N minutes" as one gesture
+
+    /// The point of the change: asking for fifteen minutes of keep-awake turns
+    /// keep-awake on. Before, it only armed a countdown for a switch the user
+    /// still had to find and flip themselves.
+    func testRequestEnablesKeepAwakeWhenItIsOff() {
+        XCTAssertEqual(AutoOff.request(minutes: 15, isEnabled: false, autoModeOn: false),
+                       .enableThenArmTimer(minutes: 15))
+    }
+
+    func testRequestJustArmsTimerWhenAlreadyOn() {
+        XCTAssertEqual(AutoOff.request(minutes: 30, isEnabled: true, autoModeOn: false),
+                       .armTimer(minutes: 30))
+    }
+
+    /// "No limit" removes the countdown. It must not also turn keep-awake off —
+    /// that's a different request, and the master toggle already expresses it.
+    func testRequestForNoLimitCancelsTimerWithoutDisabling() {
+        XCTAssertEqual(AutoOff.request(minutes: 0, isEnabled: true, autoModeOn: false),
+                       .cancelTimer)
+        XCTAssertEqual(AutoOff.request(minutes: 0, isEnabled: false, autoModeOn: false),
+                       .cancelTimer)
+    }
+
+    /// Auto mode owns activation; a countdown there would disarm the feature
+    /// behind its back. Nothing happens, including no persisted change.
+    func testRequestIsIgnoredInAutoModeWhateverElseIsTrue() {
+        for minutes in [0, 15, 240] {
+            for enabled in [true, false] {
+                XCTAssertEqual(AutoOff.request(minutes: minutes, isEnabled: enabled, autoModeOn: true),
+                               .ignoredInAutoMode,
+                               "minutes=\(minutes) enabled=\(enabled)")
+            }
+        }
+    }
+
+    func testRequestCoversEveryPreset() {
+        for minutes in AutoOff.presetMinutes {
+            XCTAssertEqual(AutoOff.request(minutes: minutes, isEnabled: false, autoModeOn: false),
+                           .enableThenArmTimer(minutes: minutes))
+        }
+    }
+
+    func testDurationLabelNamesTheNoLimitCase() {
+        XCTAssertEqual(AutoOff.durationLabel(minutes: 0), "No limit")
+        XCTAssertEqual(AutoOff.durationLabel(minutes: 15), "15 min")
+        XCTAssertEqual(AutoOff.durationLabel(minutes: 60), "1 hour")
+    }
+
     func testAutoOffOptionLabels() {
         XCTAssertEqual(AutoOff.optionLabel(minutes: 15), "15 min")
         XCTAssertEqual(AutoOff.optionLabel(minutes: 30), "30 min")


### PR DESCRIPTION
Chọn "15 min" thì keep-awake **tự bật**, và sau 15 phút **tự tắt**. Một thao tác.

## Vấn đề

Nửa "sau X phút tự tắt" đã có sẵn và chạy tốt. Thiếu nửa còn lại: `setAutoOffMinutes` chỉ arm countdown khi keep-awake **đã bật sẵn**:

```swift
if isEnabled { armAutoOff() } else { cancelAutoOff() }
```

Nên nó là một *preference* ("bật rồi thì 15 phút nữa tắt"), nằm trong Settings dưới tiêu đề "Auto-off timer" — cách xa cái toggle mà nó điều khiển. Chọn thời lượng lúc keep-awake đang tắt thì **trông như không có gì xảy ra**.

## Thay đổi

`keepAwakeFor(minutes:)` thay `setAutoOffMinutes(_:)`. Quyết định tách thành hàm thuần trong `Sources/Shared/AutoOff.swift` để test được:

```swift
AutoOff.request(minutes:isEnabled:autoModeOn:)
  -> .ignoredInAutoMode | .cancelTimer | .armTimer | .enableThenArmTimer
```

Control chuyển vào **popover ngay dưới toggle chính**, vì nó chỉnh đúng cái toggle đó — "cái switch bên trên bật trong bao lâu". Mục trong Settings **bỏ hẳn** chứ không giữ song song: hai lối vào cho một khái niệm chỉ là thêm một thứ phải giữ đồng bộ.

**Dùng Menu chứ không dùng Picker.** Binding của Picker chỉ fire khi giá trị *đổi*, nên sau khi timer hết giờ, chọn lại đúng 15 phút sẽ không làm gì cả — đúng lúc người ta muốn thêm 15 phút nữa. Đã verify bằng quan sát (xem dưới).

**Thứ tự khi phải bật:** persist thời lượng → gửi write → arm countdown từ *confirmation* của write. Nếu safety policy từ chối (pin yếu, máy nóng) thì không có timer nào đếm ngược cho một trạng thái chưa từng xảy ra.

`No limit` bỏ countdown nhưng **không** tắt keep-awake — bỏ giới hạn thời gian không phải là yêu cầu dừng, và toggle chính đã làm việc đó.

Auto mode vẫn tự quyết định bật/tắt, nên control nằm im ở đó kèm câu giải thích (giữ nguyên hành vi cũ, chỉ chuyển chỗ hiển thị).

## Đã chạy thật, không chỉ test

Drive app qua Accessibility, đọc `pmset -g` làm bằng chứng:

| Thao tác | Kết quả |
|---|---|
| Auto mode BẬT | control `enabled=false` + "Not used while…" |
| Tắt auto mode | control `enabled=true`, nhãn "No limit" |
| keep-awake đang tắt (`SleepDisabled 0`), chọn **15 min** | `SleepDisabled` → **1**, toggle → on, "Turning off in 14:59" |
| Chọn **No limit** | `SleepDisabled` vẫn **1**, countdown biến mất |
| Chọn 15 min, đợi 12s, chọn **lại** 15 min | 14:59 → 14:47 → **14:59** (restart đúng) |

Trạng thái máy đã khôi phục nguyên trạng sau khi test.

117 → 123 test, 0 failure, 0 warning mới.

## Chưa verify

Đường hết-giờ-thật (đợi trọn 15 phút rồi xem nó tự tắt). Logic đó không đổi trong PR này — `autoOffTick` giữ nguyên — nhưng nếu bạn muốn chắc thì hẹn 15 phút rồi để đó, hoặc tôi thêm preset ngắn `#if DEBUG` để test cho nhanh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
