### PR TITLE
Release 0.1.3

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -41,7 +41,7 @@ targets:
         SUScheduledCheckInterval: 86400
     settings:
       base:
-        MARKETING_VERSION: "0.1.2"
+        MARKETING_VERSION: "0.1.3"
         CURRENT_PROJECT_VERSION: "1"
         ENABLE_HARDENED_RUNTIME: YES
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -65,7 +65,16 @@ BUILD_NUMBER="${BUILD_NUMBER:-$(git rev-list --count HEAD)}"
 # Guard: refuse to ship a build number that isn't greater than the last shipped
 # one (read from the committed, published feed — the durable source of truth).
 if [ -f "$PAGES_APPCAST" ]; then
-    LAST=$(/usr/bin/sed -n 's/.*sparkle:version="\([0-9][0-9]*\)".*/\1/p' "$PAGES_APPCAST" | sort -n | tail -n1)
+    # Match the element form `<sparkle:version>66</sparkle:version>`, which is
+    # what generate_appcast writes, as well as the attribute form some Sparkle
+    # versions emit. Matching only the attribute meant this guard found nothing
+    # and silently never fired — a shipped build number that failed to increase
+    # would have gone out unnoticed, and Sparkle would then offer the update to
+    # nobody, which is the kind of failure users never report.
+    LAST=$(/usr/bin/sed -n \
+        -e 's/.*<sparkle:version>\([0-9][0-9]*\)<.*/\1/p' \
+        -e 's/.*sparkle:version="\([0-9][0-9]*\)".*/\1/p' \
+        "$PAGES_APPCAST" | sort -n | tail -n1)
     if [ -n "${LAST:-}" ] && [ "$BUILD_NUMBER" -le "$LAST" ]; then
         echo "✗ BUILD_NUMBER ($BUILD_NUMBER) must be > last shipped sparkle:version ($LAST). Override with BUILD_NUMBER=…" >&2
         exit 1


### PR DESCRIPTION
Bump `MARKETING_VERSION` to 0.1.3 và sửa build-number guard trong `scripts/release.sh`.

## Guard chưa bao giờ chạy

Guard đọc build number cuối từ feed đã publish rồi từ chối mọi số không lớn hơn. Nhưng nó tìm dạng **attribute**:

```
sparkle:version="66"
```

trong khi `generate_appcast` ghi dạng **element**:

```xml
<sparkle:version>66</sparkle:version>
```

nên nó khớp 0 dòng và im lặng không bao giờ fire. Một release lùi số build sẽ đi qua sạch sẽ, rồi Sparkle không đẩy update cho **ai cả** — kiểu hỏng mà user không bao giờ report được, vì từ phía họ thì đúng là không có gì xảy ra.

Cùng một lớp lỗi với `if:` trong CI vừa sửa ở #28: một cơ chế an toàn im lặng không hoạt động thì tệ hơn là không có, vì nó tạo cảm giác an toàn giả.

Giờ khớp cả hai dạng. Với feed hiện tại nó đọc ra 66, nên build 74 của release này **được kiểm** chứ không phải được cho qua.

## Nội dung 0.1.3

- **Hẹn giờ keep-awake** (#28) — chọn "15 min" thì keep-awake tự bật, sau 15 phút tự tắt. Control chuyển vào popover ngay dưới toggle.
- **Siết XPC** (#27) — helper yêu cầu peer đúng là app Lidless (`setCodeSigningRequirement`) trước khi trao object chạy root. Trước đó mọi process local đều bảo được root daemon giữ máy thức vô thời hạn.
- **CI chạy thật trên PR** (#28) — workflow trước đó skip mọi pull request.

134 test, 0 failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)